### PR TITLE
Fix #4.

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,8 +1,8 @@
-SUITESPARSE_LDL_SOLVER=0
-MKL_PARDISO_SOLVER=1
+const SUITESPARSE_LDL_SOLVER=0
+const MKL_PARDISO_SOLVER=1
 
 # Define OSQP infinity constants
-OSQP_INFTY = 1e20
+const OSQP_INFTY = 1e20
 
 # OSQP return values
 # https://github.com/oxfordcontrol/osqp/blob/master/include/constants.h
@@ -18,13 +18,13 @@ const status_map = Dict{Int, Symbol}(
     -10 => :Unsolved
 )
 
-SOLUTION_PRESENT = [:Solved_inaccurate, :Solved, :Max_iter_reached]
+const SOLUTION_PRESENT = [:Solved_inaccurate, :Solved, :Max_iter_reached]
 
 # UPDATABLE_DATA
-UPDATABLE_DATA = [:q, :l, :u, :Px, :Px_idx, :Ax, :Ax_idx]
+const UPDATABLE_DATA = [:q, :l, :u, :Px, :Px_idx, :Ax, :Ax_idx]
 
 # UPDATABLE_SETTINGS
-UPDATABLE_SETTINGS = [:max_iter, :eps_aps, :eps_rel, :eps_prim_inf, :eps_dual_inf,
+const UPDATABLE_SETTINGS = [:max_iter, :eps_aps, :eps_rel, :eps_prim_inf, :eps_dual_inf,
               :rho, :alpha, :delta, :polish, :polish_refine_iter, :verbose,
               :check_termination,:warm_start]
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -216,6 +216,7 @@ function solve!(model::OSQP.Model)
                 return Results(x, y, info, nothing, dual_inf_cert)  
         end
     end
+    error() # fixes #4
 end
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,9 +3,9 @@
 
 # Integer type from C
 if Sys.WORD_SIZE == 64   # 64bit system
-    Cc_int = Clonglong
+    const Cc_int = Clonglong
 else  # 32bit system
-    Cc_int = Cint
+    const Cc_int = Cint
 end
 
 struct Ccsc


### PR DESCRIPTION
* make constants `const`. Technically, #4 only showed an issue with `SOLUTION_PRESENT`, but making the others `const` as well doesn't hurt.
* add `error()` to the end of `solve!`. For some reason, on 0.6.2 inference can't figure out that all of the possible branches return a `Result`.