### PR TITLE
WIP: Implement MathOptInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ addons:
       - cmake-data
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterface.jl.git"); Pkg.checkout("MathOptInterface", "tk/interval-constructors-rebased")'
- - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git")'
+ - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterface.jl.git")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("OSQP"); Pkg.test("OSQP"; coverage=true)'
 after_success:
   # # push coverage results to Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ addons:
       - cmake-data
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterface.jl.git"); Pkg.checkout("MathOptInterface", "tk/interval-constructors")'
+ - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterface.jl.git"); Pkg.checkout("MathOptInterface", "tk/interval-constructors-rebased")'
  - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git")'
- - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterfaceTests.jl.git"); Pkg.checkout("MathOptInterfaceTests", "tk/affine-duplicate")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("OSQP"); Pkg.test("OSQP"; coverage=true)'
 after_success:
   # # push coverage results to Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
       - cmake-data
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+ - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterface.jl.git"); Pkg.checkout("MathOptInterface", "tk/interval-constructors")'
+ - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git")'
+ - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterfaceTests.jl.git"); Pkg.checkout("MathOptInterfaceTests", "tk/affine-duplicate")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("OSQP"); Pkg.test("OSQP"; coverage=true)'
 after_success:
   # # push coverage results to Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
       - cmake-data
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterface.jl.git")'
+ - julia -e 'Pkg.clone("https://github.com/tkoolen/MathOptInterface.jl.git"); Pkg.checkout("MathOptInterface", "tk/osqp")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("OSQP"); Pkg.test("OSQP"; coverage=true)'
 after_success:
   # # push coverage results to Coveralls

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -388,13 +388,13 @@ MOI.get(optimizer::OSQPOptimizer, ::MOI.ObjectiveSense) = optimizer.sense
 MOI.canget(optimizer::OSQPOptimizer, ::MOI.NumberOfVariables) = !MOI.isempty(optimizer) # https://github.com/oxfordcontrol/OSQP.jl/issues/10
 function MOI.get(optimizer::OSQPOptimizer, a::MOI.NumberOfVariables)
     MOI.canget(optimizer, a) || error()
-    OSQP.dimensions(optimizer.model)[1]
+    OSQP.dimensions(optimizer.inner)[1]
 end
 
 MOI.canget(optimizer::OSQPOptimizer, ::MOI.ListOfVariableIndices) = MOI.canget(optimizer, MOI.NumberOfVariables())
 function MOI.get(optimizer::OSQPOptimizer, a::MOI.ListOfVariableIndices)
     MOI.canget(optimizer, a) || error()
-    [VI(i) for i = 1 : get(optimizer, MOI.NumberOfVariables())] # TODO: support for UnitRange would be nice
+    [VI(i) for i = 1 : MOI.get(optimizer, MOI.NumberOfVariables())] # TODO: support for UnitRange would be nice
 end
 
 
@@ -575,7 +575,7 @@ end
 
 
 ## Variables:
-MOI.isvalid(optimizer::OSQPOptimizer, vi::VI) = MOI.canget(optimizer, MOI.NumberOfVariables()) && vi.value ∈ 1 : get(optimizer, MOI.NumberOfVariables())
+MOI.isvalid(optimizer::OSQPOptimizer, vi::VI) = MOI.canget(optimizer, MOI.NumberOfVariables()) && vi.value ∈ 1 : MOI.get(optimizer, MOI.NumberOfVariables())
 MOI.canaddvariable(optimizer::OSQPOptimizer) = false
 
 

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -446,7 +446,8 @@ function MOI.optimize!(optimizer::OSQPOptimizer)
     copy!(optimizer.warmstartcache.y.data, optimizer.results.y)
 end
 
-MOI.free!(optimizer::OSQPOptimizer) = OSQP.clean!(optimizer.inner)
+# OSQP.Model already sets up a finalizer that calls OSQP.clean!. Manually calling it would result in a double free.
+# MOI.free!(optimizer::OSQPOptimizer) = OSQP.clean!(optimizer.inner)
 
 
 ## Optimizer attributes:

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -186,11 +186,11 @@ function processconstraints!(triplets::SparseTriplets, bounds::Tuple{<:Vector, <
         row = idxmap[ci].value
         l[row] = s.lower - constant(f)
         u[row] = s.upper - constant(f)
-        processconstraints!(triplets, f, row, idxmap)
+        processconstraintfun!(triplets, f, row, idxmap)
     end
 end
 
-function processconstraints!(triplets::SparseTriplets, f::MOI.SingleVariable, row::Int, idxmap)
+function processconstraintfun!(triplets::SparseTriplets, f::MOI.SingleVariable, row::Int, idxmap)
     (I, J, V) = triplets
     col = idxmap[f.variable].value
     push!(I, row)
@@ -199,7 +199,7 @@ function processconstraints!(triplets::SparseTriplets, f::MOI.SingleVariable, ro
     nothing
 end
 
-function processconstraints!(triplets::SparseTriplets, f::MOI.ScalarAffineFunction, row::Int, idxmap)
+function processconstraintfun!(triplets::SparseTriplets, f::MOI.ScalarAffineFunction, row::Int, idxmap)
     (I, J, V) = triplets
     ncoeff = length(f.coefficients)
     @assert length(f.variables) == ncoeff

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -223,15 +223,19 @@ MOI.get(optimizer::OSQPOptimizer, ::MOI.SolveTime) = optimizer.results.info.run_
 
 MOI.canget(optimizer::OSQPOptimizer, ::MOI.TerminationStatus) = hasresults(optimizer)
 function MOI.get(optimizer::OSQPOptimizer, ::MOI.TerminationStatus)
+    # Note that the :Dual_infeasible and :Primal_infeasible are mapped to MOI.Success
+    # because OSQP can return a proof of infeasibility. For the same reason,
+    # :Primal_infeasible_inaccurate is mapped to MOI.AlmostSuccess
+
     osqpstatus = optimizer.results.info.status
     if osqpstatus == :Unsolved
         error("Problem is unsolved.") # TODO: good idea?
     elseif osqpstatus == :Interrupted
         MOI.Interrupted
     elseif osqpstatus == :Dual_infeasible
-        MOI.InfeasibleOrUnbounded
+        MOI.Success
     elseif osqpstatus == :Primal_infeasible
-        MOI.InfeasibleNoResult
+        MOI.Success
     elseif osqpstatus == :Max_iter_reached
         MOI.IterationLimit
     elseif osqpstatus == :Solved
@@ -239,7 +243,7 @@ function MOI.get(optimizer::OSQPOptimizer, ::MOI.TerminationStatus)
     elseif osqpstatus == :Solved_inaccurate
         MOI.AlmostSuccess
     elseif osqpstatus == :Primal_infeasible_inaccurate
-        MOI.InfeasibleNoResult
+        MOI.AlmostSuccess
     end
 end
 

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -675,7 +675,7 @@ end
 MOI.canmodifyobjective(optimizer::OSQPOptimizer, ::Type{<:MOI.ScalarConstantChange}) = !MOI.isempty(optimizer)
 function MOI.modifyobjective!(optimizer::OSQPOptimizer, change::MOI.ScalarConstantChange)
     MOI.canmodifyobjective(optimizer, typeof(change)) || error()
-    optimizer.objconst = change.new_constant
+    optimizer.objconstant = change.new_constant
 end
 
 MOI.canmodifyobjective(optimizer::OSQPOptimizer, ::Type{<:MOI.ScalarCoefficientChange}) = !MOI.isempty(optimizer)

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -192,7 +192,7 @@ function processconstraintfun!(A::AbstractMatrix, row::Int, idxmap, f::Affine)
         var = f.variables[i]
         coeff = f.coefficients[i]
         col = idxmap[var].value
-        A[row, col] = coeff
+        A[row, col] += coeff
     end
     nothing
 end

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -1,0 +1,271 @@
+module MathOptInterfaceOSQP
+
+export OSQPInstance
+
+using Compat
+using MathOptInterface
+using MathOptInterfaceUtilities
+
+const MOI = MathOptInterface
+const MOIU = MathOptInterfaceUtilities
+const CI = MOI.ConstraintIndex
+const VI = MOI.VariableIndex
+
+import OSQP
+import MathOptInterfaceUtilities: IndexMap
+
+mutable struct OSQPInstance <: MOI.AbstractSolverInstance
+    inner::OSQP.Model
+    results::Union{OSQP.Results, Nothing}
+    isempty::Bool
+    # TODO: constant term?
+
+    OSQPInstance() = new(OSQP.Model(), nothing, true)
+end
+
+hasresults(instance::OSQPInstance) = instance.results != nothing
+
+function MOI.empty!(instance::OSQPInstance)
+    instance.inner = OSQP.Model()
+    instance.results = nothing
+    instance.isempty = true
+end
+
+MOI.isempty(instance::OSQPInstance) = instance.isempty
+
+function MOI.copy!(dest::OSQPInstance, src::MOI.AbstractInstance)
+    MOI.empty!(dest)
+
+    # Set up index map
+    idxmap = MOI.IndexMap() # TODO: could even get a typed one
+    vis_src = MOI.get(src, MOI.ListOfVariableIndices())
+    for i in eachindex(vis_src)
+        idxmap[vis_src[i]] = VI(i)
+    end
+    cis_src = MOI.get(src, MOI.ListOfConstraintIndices())
+    for i in eachindex(cis_src)
+        ci_src = cis_src[i]
+        if ci_src isa CI{MOI.ScalarAffineFunction, MOI.Interval}
+            idxmap[cis_src[i]] = CI{MOI.ScalarAffineFunction, MOI.Interval}(i)
+        else
+            return MOI.CopyResult(MOI.CopyUnsupportedConstraint, "Unsupported constraint of type $(typeof(ci_src))", idxmap)
+        end
+    end
+
+    # Get sizes
+    @assert MOI.canget(src, MOI.NumberOfVariables())
+    n = MOI.get(src, MOI.NumberOfVariables())
+    @assert MOI.canget(src, MOI.NumberOfConstraints())
+    m = MOI.get(src, MOI.NumberOfConstraints())
+
+    # Allocate storage for problem data
+    P = spzeros(n, n)
+    q = zeros(n)
+    A = spzeros(m, n)
+    l = zeros(m)
+    u = zeros(m)
+
+    # Process objective function
+    @assert MOI.canget(src, MOI.ObjectiveFunction())
+    obj = MOI.get(src, MOI.ObjectiveFunction())
+    processobjective!(P, q, obj, idxmap)
+    # TODO: constant term
+
+    # Process instance attributes
+    @assert MOI.get(src, MOI.ObjectiveSense()) == MOI.get(dest, MOI.ObjectiveSense())
+
+    # Process variable attributes
+    # TODO: VariablePrimalStart
+
+    # Process constraint attributes
+    # TODO: ConstraintPrimalStart
+    # TODO: ConstraintDualStart
+
+
+    OSQP.setup!(dest.inner; P = P, q = q, A = A, l = l, u = u) # TODO: settings
+
+    dest.isempty = false
+
+    return MOI.CopyResult(MOI.CopySuccess, "", idxmap)
+end
+
+function process_affine_objective!(P::SparseMatrixCSC, q::Vector, variables::Vector{VI}, coefficients::Vector, idxmap)
+    q[:] = 0
+    n = length(coefficients)
+    @assert length(variables) == n
+    for i = 1 : n
+        q[idxmap[var[i]].value] += coefficients[i]
+    end
+end
+
+function processobjective!(P::SparseMatrixCSC, q::Vector, objfun::MOI.ScalarAffineFunction, idxmap)
+    process_affine_objective!(P, q, objfun.variables, objfun.coefficients, idxmap)
+end
+
+function processobjective!(P::SparseMatrixCSC, q::Vector, objfun::MOI.ScalarQuadraticFunction, idxmap)
+    process_affine_objective!(P, q, objfun.affine_variables, objfun.affine_coefficients, idxmap)
+    nquadratic = length(objfun.quadratic_coefficients)
+    @assert length(objfun.quadratic_rowvariables) == length(objfun.quadratic_colvariables) == nquadratic
+    P[:] = 0
+    for i = 1 : nquadratic
+        row = idxmap[objfun.quadratic_rowvariables[i]].value
+        col = idxmap[objfun.quadratic_colvariables[i]].value
+        P[row, col] += objfun.quadratic_coefficients[i]
+        P[col, row] = P[row, col]
+    end
+end
+
+function processobjective!(P::SparseMatrixCSC, q::Vector, objfun::MOI.SingleVariable, idxmap)
+    q[:] = 0
+    P[:] = 0
+    q[idxmap[objfun.variable.value]] = 1
+    nothing
+end
+
+
+## Instance attributes:
+MOI.canget(instance::OSQPInstance, ::MOI.ObjectiveSense) = true
+MOI.get(instance::OSQPInstance, ::MOI.ObjectiveSense) = MOI.MinSense
+
+MOI.canget(instance::OSQPInstance, ::MOI.NumberOfVariables) = !instance.isempty # https://github.com/oxfordcontrol/OSQP.jl/issues/10
+MOI.get(instance::OSQPInstance, ::MOI.NumberOfVariables) = OSQP.dimensions(instance.model)[1]
+
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfVariableIndices) = MOI.get(instance, MOI.NumberOfVariables())
+MOI.get(instance::OSQPInstance, ::MOI.ListOfVariableIndices) = [VI(i) for i = 1 : get(instance, MOI.NumberOfVariables())] # TODO: support for UnitRange would be nice
+
+MOI.canget(instance::OSQPInstance, ::MOI.NumberOfConstraints) = !instance.isempty # https://github.com/oxfordcontrol/OSQP.jl/issues/10
+MOI.get(instance::OSQPInstance, ::MOI.NumberOfConstraints) = OSQP.dimensions(instance.model)[2]
+
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfConstraints) = false # TODO
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfConstraintIndices) = false # TODO
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfInstanceAttributesSet) = false # currently not exposed
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfVariableAttributesSet) = false # currently not exposed (for warmstart, rest is N/A)
+MOI.canget(instance::OSQPInstance, ::MOI.ListOfConstraintAttributesSet) = false # currently not exposed
+
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintPrimal, ::CI) = false # constraint primal (or A matrix) not currently exposed by OSQP interface
+
+
+## Solver instance:
+MOI.optimize!(instance::OSQPInstance) = (instance.results = OSQP.solve!(instance.inner))
+MOI.free!(instance::OSQPInstance) = OSQP.clean!(instance.inner)
+
+
+## Solver instance attributes:
+MOI.canget(instance::OSQPInstance, ::MOI.RawSolver) = true
+MOI.get(instance::OSQPInstance, ::MOI.RawSolver) = instance.inner
+
+MOI.canget(instance::OSQPInstance, ::MOI.ResultCount) = hasresults(instance) # TODO: or true?
+MOI.get(instance::OSQPInstance, ::MOI.ResultCount) = 1
+
+MOI.canget(instance::OSQPInstance, ::MOI.ObjectiveFunction) = false # currently not exposed
+
+MOI.canget(instance::OSQPInstance, ::MOI.ObjectiveValue) = hasresults(instance)
+MOI.get(instance::OSQPInstance, ::MOI.ObjectiveValue) = instance.results.info.obj_val
+
+MOI.canget(instance::OSQPInstance, ::MOI.ObjectiveBound) = false # currently not exposed
+MOI.canget(instance::OSQPInstance, ::MOI.RelativeGap) = false # currently not exposed
+
+MOI.canget(instance::OSQPInstance, ::MOI.SolveTime) = hasresults(instance)
+MOI.get(instance::OSQPInstance, ::MOI.SolveTime) = instance.results.info.run_time
+
+MOI.canget(instance::OSQPInstance, ::MOI.TerminationStatus) = hasresults(instance)
+function MOI.get(instance::OSQPInstance, ::MOI.TerminationStatus)
+    osqpstatus = instance.results.info.status
+    if osqpstatus == :Unsolved
+        error("Problem is unsolved.") # TODO: good idea?
+    elseif osqpstatus == :Interrupted
+        MOI.Interrupted
+    elseif osqpstatus == :Dual_infeasible
+        MOI.InfeasibleOrUnbounded
+    elseif osqpstatus == :Primal_infeasible
+        MOI.InfeasibleNoResult
+    elseif osqpstatus == :Max_iter_reached
+        MOI.IterationLimit
+    elseif osqpstatus == :Solved
+        MOI.Success
+    elseif osqpstatus == :Solved_inaccurate
+        MOI.AlmostSuccess
+    elseif osqpstatus == :Primal_infeasible_inaccurate
+        MOI.InfeasibleNoResult
+    end
+end
+
+MOI.canget(instance::OSQPInstance, ::MOI.PrimalStatus) = hasresults(instance)
+function MOI.get(instance::OSQPInstance, ::MOI.PrimalStatus)
+    osqpstatus = instance.results.info.status
+    if osqpstatus == :Unsolved
+        error("Problem is unsolved.") # TODO: good idea?
+    elseif osqpstatus == :Primal_infeasible
+        MOI.InfeasibilityCertificate
+    elseif osqpstatus == :Solved
+        MOI.FeasiblePoint
+    elseif osqpstatus == :Primal_infeasible_inaccurate
+        MOI.NearlyInfeasibilityCertificate
+    else # :Interrupted, :Dual_infeasible, :Max_iter_reached, :Solved_inaccurate (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
+        MOI.UnknownResultStatus
+    end
+end
+
+MOI.canget(instance::OSQPInstance, ::MOI.DualStatus) = hasresults(instance)
+function MOI.get(instance::OSQPInstance, ::MOI.DualStatus)
+    osqpstatus = instance.results.info.status
+    if osqpstatus == :Unsolved
+        error("Problem is unsolved.") # TODO: good idea?
+    elseif osqpstatus == :Dual_infeasible
+        MOI.InfeasibilityCertificate
+    elseif osqpstatus == :Solved
+        MOI.FeasiblePoint
+    else # :Interrupted, :Primal_infeasible, :Max_iter_reached, :Primal_infeasible_inaccurate, :Solved_inaccurate (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
+        MOI.UnknownResultStatus
+    end
+end
+
+# TODO: solver-specific attributes
+
+
+## Variables and constraints:
+MOI.candelete(instance::OSQPInstance, index::MOI.Index) = false
+MOI.isvalid(instance::OSQPInstance, vi::VI) = vi.value ∈ 1 : get(instance, MOI.NumberOfVariables())
+MOI.canaddvariable(instance::OSQPInstance) = false
+
+
+## Variable attributes:
+MOI.canget(instance::OSQPInstance, ::MOI.VariablePrimalStart, ::Type{VI}) = false # currently not exposed, but could be
+MOI.canset(instance::OSQPInstance, ::MOI.VariablePrimalStart, ::Type{VI}) = false # TODO: need selective way of updating primal start
+
+MOI.canget(instance::OSQPInstance, ::MOI.VariablePrimal, ::VI) = hasresults(instance) && instance.results.info.status ∈ OSQP.SOLUTION_PRESENT
+MOI.get(instance::OSQPInstance, ::MOI.VariablePrimal, vi::VI) = instance.results.x[vi.value]
+MOI.get(instance::OSQPInstance, a::MOI.VariablePrimal, vi::Vector{VI}) = MOI.get.(instance, a, vi) # TODO: copied from SCS. Necessary?
+
+
+## Constraints:
+MOI.isvalid(instance::OSQPInstance, ci::CI) = ci.value ∈ 1 : get(instance, MOI.NumberOfConstraints())
+MOI.canaddconstraint(instance::OSQPInstance, ::Type{F}, ::Type{S}) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet} = false
+
+# TODO: can't modifyconstraint! with AbstractFunction because selective way to update A not exposed
+MOI.canmodifyconstraint(instance::OSQPInstance, ci::CI{MOI.ScalarAffineFunction, MOI.Interval}, ::Type{MOI.ScalarAffineFunction}) = false
+# MOI.modifyconstraint!(instance::OSQPInstance, ci::CI{MOI.ScalarAffineFunction, MOI.Interval}, func::MOI.ScalarAffineFunction)
+
+# TODO: can't modifyconstraint! with AbstractSet because selective way to update lb and ub not exposed
+MOI.canmodifyconstraint(instance::OSQPInstance, ci::CI{MOI.ScalarAffineFunction, MOI.Interval}, ::Type{MOI.Interval}) = false
+# MOI.modifyconstraint!(instance::OSQPInstance, ci::CI{MOI.ScalarAffineFunction, MOI.Interval}, set::MOI.Interval)
+
+# TODO: partial change with MultirowChange
+
+MOI.supportsconstraint(instance::OSQPInstance, ::Type{MOI.ScalarAffineFunction}, ::Type{MOI.Interval}) = true
+
+
+## Constraint attributes:
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintPrimalStart, ::Type{<:CI}) = false # currently not exposed, but could be
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintDualStart, ::Type{<:CI}) = false # currently not exposed, but could be
+MOI.canset(instance::OSQPInstance, ::MOI.ConstraintDualStart, ::Type{VI}) = false # TODO: need selective way of updating primal start
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintPrimal, ::Type{<:CI}) = false # currently not exposed, but could be
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintDual, ::Type{<:CI}) = false # currently not exposed, but could be
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintFunction, ::Type{<:CI}) = false # TODO
+MOI.canget(instance::OSQPInstance, ::MOI.ConstraintSet, ::Type{<:CI}) = false # TODO
+
+
+# Objective modification
+MOI.canmodifyobjective(instance::OSQPInstance, ::Type{MOI.ScalarCoefficientChange}) = false # TODO: selective way of updating objective coefficients not exposed
+
+end # module

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -502,8 +502,9 @@ function MOI.get(optimizer::OSQPOptimizer, a::MOI.ObjectiveValue)
     ifelse(optimizer.sense == MOI.MaxSense, -rawobj, rawobj)
 end
 
-MOI.canget(optimizer::OSQPOptimizer, ::MOI.ObjectiveBound) = false # TODO
-MOI.canget(optimizer::OSQPOptimizer, ::MOI.RelativeGap) = false # TODO
+# Since these aren't explicitly returned by OSQP, I feel like it would be better to have a fallback method compute these:
+# MOI.canget(optimizer::OSQPOptimizer, ::MOI.ObjectiveBound) = false
+# MOI.canget(optimizer::OSQPOptimizer, ::MOI.RelativeGap) = false
 
 MOI.canget(optimizer::OSQPOptimizer, ::MOI.SolveTime) = hasresults(optimizer)
 MOI.get(optimizer::OSQPOptimizer, a::MOI.SolveTime) = (MOI.canget(optimizer, a) || error(); optimizer.results.info.run_time)

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -219,7 +219,7 @@ function processobjective(src::MOI.ModelLike, idxmap)
         if MOI.canget(src, MOI.ObjectiveFunction{SingleVariable}())
             fsingle = MOI.get(src, MOI.ObjectiveFunction{SingleVariable}())
             P = spzeros(n, n)
-            q[idxmap[fsingle.variable.value]] = 1
+            q[idxmap[fsingle.variable].value] = 1
             c = 0.
         elseif MOI.canget(src, MOI.ObjectiveFunction{Affine}())
             faffine = MOI.get(src, MOI.ObjectiveFunction{Affine}())

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -1,6 +1,6 @@
 module MathOptInterfaceOSQP
 
-export OSQPOptimizer, OSQPSettings
+export OSQPOptimizer, OSQPSettings, OSQPModel
 
 using Compat
 using MathOptInterface
@@ -640,5 +640,16 @@ function MOI.modifyobjective!(optimizer::OSQPOptimizer, change::MOI.ScalarCoeffi
 end
 
 # There is currently no ScalarQuadraticCoefficientChange.
+
+MOIU.@model(OSQPModel, # modelname
+    (), # scalarsets
+    (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets
+    (), # vectorsets
+    (), # typedvectorsets
+    (SingleVariable,), # scalarfunctions
+    (ScalarAffineFunction, ScalarQuadraticFunction), # typedscalarfunctions
+    (), # vectorfunctions
+    () # typedvectorfunctions
+)
 
 end # module

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -378,7 +378,11 @@ function MOI.get(optimizer::OSQPOptimizer, ::MOI.VariablePrimal, vi::VI)
     if optimizer.results.info.status in OSQP.SOLUTION_PRESENT
         return optimizer.results.x[vi.value]
     else
-        return optimizer.results.dual_inf_cert[vi.value]
+        if optimizer.results.dual_inf_cert != nothing
+            return optimizer.results.dual_inf_cert[vi.value]
+        else
+            error("Variable primal not available")
+        end
     end
 end
 
@@ -414,7 +418,11 @@ function MOI.get(optimizer::OSQPOptimizer, ::MOI.ConstraintDual, ci::CI)
     if optimizer.results.info.status in OSQP.SOLUTION_PRESENT
         return -optimizer.results.y[ci.value]
     else
-        return -optimizer.results.prim_inf_cert[ci.value]
+        if optimizer.results.prim_inf_cert != nothing
+            return -optimizer.results.prim_inf_cert[ci.value]
+        else
+            error("Constraint dual not available.")
+        end
     end
 end
 

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -4,10 +4,10 @@ export OSQPOptimizer, OSQPSettings
 
 using Compat
 using MathOptInterface
-using MathOptInterfaceUtilities
+using MathOptInterface.Utilities
 
 const MOI = MathOptInterface
-const MOIU = MathOptInterfaceUtilities
+const MOIU = MathOptInterface.Utilities
 const CI = MOI.ConstraintIndex
 const VI = MOI.VariableIndex
 

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -647,8 +647,8 @@ function MOI.modifyconstraint!(optimizer::OSQPOptimizer, ci::CI{<:AffineConverti
 end
 
 # partial function modification:
-MOI.canmodifyconstraint(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, ::Type{MOI.ScalarCoefficientChange{<:Real}}) = MOI.isvalid(optimizer, ci)
-function MOI.modifyconstraint!(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, change::MOI.ScalarCoefficientChange{<:Real})
+MOI.canmodifyconstraint(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, ::Type{<:MOI.ScalarCoefficientChange}) = MOI.isvalid(optimizer, ci)
+function MOI.modifyconstraint!(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, change::MOI.ScalarCoefficientChange)
     MOI.canmodifyconstraint(optimizer, ci, typeof(change)) || error()
     optimizer.modcache.A[ci.value, change.variable.value] = change.new_coefficient
 end

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -586,7 +586,7 @@ end
 # partial function modification:
 MOI.canmodifyconstraint(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, ::Type{MOI.ScalarCoefficientChange{<:Real}}) = MOI.isvalid(optimizer, ci)
 function MOI.modifyconstraint!(optimizer::OSQPOptimizer, ci::CI{Affine, <:IntervalConvertible}, change::MOI.ScalarCoefficientChange{<:Real})
-    optimizer.modcache.Acache[ci.value, change.variable] = change.new_coefficient
+    optimizer.modcache.Acache[ci.value, change.variable.value] = change.new_coefficient
 end
 
 # TODO: MultirowChange?

--- a/src/OSQP.jl
+++ b/src/OSQP.jl
@@ -34,5 +34,6 @@ include("constants.jl")
 include("types.jl")
 include("interface.jl")
 include("mpbinterface.jl")
+include("MathOptInterfaceOSQP.jl")
 
 end # module

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -108,8 +108,7 @@ function defaultoptimizer()
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOI.set!(optimizer, OSQPSettings.MaxIter(), 10000)
-    MOI.set!(optimizer, OSQPSettings.AdaptiveRho(), false) # required for deterministic behavior
-    # MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25)
+    MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior
     optimizer
 end
 

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -108,7 +108,8 @@ function defaultoptimizer()
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOI.set!(optimizer, OSQPSettings.MaxIter(), 10000)
-    # MOI.set!(optimizer, OSQPSettings.CheckTermination(), true) # This seems to cause random test failures!
+    MOI.set!(optimizer, OSQPSettings.AdaptiveRho(), false) # required for deterministic behavior
+    # MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25)
     optimizer
 end
 
@@ -228,9 +229,7 @@ end
 
     # ensure that solving a second time results in the same answer after zeroing warm start
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
-    # TODO: I would have expected this to pass:
-    # test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), MOIT.TestConfig(atol=0.0, rtol=0.0))
-    test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), config)
+    test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), MOIT.TestConfig(atol=0.0, rtol=0.0))
 
     mapfrommodel(::MOI.AbstractOptimizer, x::Union{MOI.VariableIndex, <:MOI.ConstraintIndex}) = idxmap[x]
     mapfrommodel(::MOI.ModelLike, x::Union{MOI.VariableIndex, <:MOI.ConstraintIndex}) = x

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -199,9 +199,13 @@ end
     optimizer = defaultoptimizer()
     copyresult = MOI.copy!(optimizer, model)
     idxmap = copyresult.indexmap
+    @test MOI.canget(optimizer, MOI.ObjectiveSense())
+    @test MOI.get(optimizer, MOI.ObjectiveSense()) == MOI.MinSense
+    @test MOI.get(optimizer, MOI.NumberOfVariables()) == 2
+    @test MOI.get(optimizer, MOI.ListOfVariableIndices()) == [MOI.VariableIndex(1), MOI.VariableIndex(2)]
+    @test MOI.isvalid(optimizer, MOI.VariableIndex(2))
+    @test !MOI.isvalid(optimizer, MOI.VariableIndex(3))
 
-    # Since OSQP automatically warm starts, we need to manually zero to get repeatable results
-    zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
     MOI.optimize!(optimizer)
 
     # ensure that unmodified model is correct

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -5,8 +5,8 @@ using Base.Test
 using MathOptInterface
 const MOI = MathOptInterface
 
-using MathOptInterfaceTests
-const MOIT = MathOptInterfaceTests
+using MathOptInterface.Test
+const MOIT = MathOptInterface.Test
 
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -8,8 +8,8 @@ const MOI = MathOptInterface
 using MathOptInterface.Test
 const MOIT = MathOptInterface.Test
 
-using MathOptInterfaceUtilities
-const MOIU = MathOptInterfaceUtilities
+using MathOptInterface.Utilities
+const MOIU = MathOptInterface.Utilities
 
 @testset "ProblemModificationCache" begin
     rng = MersenneTwister(1234)

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -239,6 +239,15 @@ end
         MOI.set!(m, MOI.ObjectiveFunction{F}(), newobjf)
     end
 
+    # add a constant to the objective
+    objval_before = MOI.get(optimizer, MOI.ObjectiveValue())
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        @test MOI.canmodifyobjective(m, MOI.ScalarConstantChange)
+        MOI.modifyobjective!(m, MOI.ScalarConstantChange(1.5))
+    end
+    objval_after = MOI.get(optimizer, MOI.ObjectiveValue())
+    @test objval_after ≈ objval_before + 1.5 atol = 1e-8
+
     # change x + y <= 1 to x + 2 y <= 1
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
     test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -42,10 +42,6 @@ end
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Continuous linear problems" begin
-    # excludes = collect(keys(MOIT.contlineartests))
-    # deleteat!(excludes, findfirst(excludes, "linear1"))
-    # deleteat!(excludes, findfirst(excludes, "linear8a"))
-
     excludes = String[]
     push!(excludes, "linear7") # vector constraints
     optimizer = OSQPOptimizer()
@@ -53,4 +49,17 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
+end
+
+@testset "Continuous quadratic problems" begin
+    excludes = String[]
+    push!(excludes, "quadratic4") # QCP
+    push!(excludes, "quadratic5") # QCP
+    push!(excludes, "quadratic6") # QCP
+    push!(excludes, "quadratic7") # SOCP
+    optimizer = OSQPOptimizer()
+    MOI.set!(optimizer, OSQPSettings.Verbose(), false)
+    MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
+    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
+    MOIT.contquadratictest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
 end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -29,16 +29,16 @@ const MOIU = MathOptInterface.Utilities
     @test baseresults.info.status == :Solved
 
     # Modify q, ensure that updating results in the same solution as calling setup! with the modified q
-    @test !modcache.qcache.dirty
-    modcache.qcache[3] = 5.
-    @test modcache.qcache.dirty
-    @test modcache.qcache.data[3] == 5.
+    @test !modcache.q.dirty
+    modcache.q[3] = 5.
+    @test modcache.q.dirty
+    @test modcache.q.data[3] == 5.
     MathOptInterfaceOSQP.processupdates!(model, modcache)
-    @test !modcache.qcache.dirty
+    @test !modcache.q.dirty
     qmod_update_results = OSQP.solve!(model)
     @test !isapprox(baseresults.x, qmod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
     model2 = OSQP.Model()
-    OSQP.setup!(model2; P = P, q = modcache.qcache.data, A = A, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    OSQP.setup!(model2; P = P, q = modcache.q.data, A = A, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
     qmod_setup_results = OSQP.solve!(model2)
     @test qmod_update_results.x ≈ qmod_setup_results.x atol = 1e-8
 
@@ -48,29 +48,29 @@ const MOIU = MathOptInterface.Utilities
     row = I[Amodindex]
     col = J[Amodindex]
     val = randn(rng)
-    modcache.Acache[row, col] = val
+    modcache.A[row, col] = val
     MathOptInterfaceOSQP.processupdates!(model, modcache)
-    @test isempty(modcache.Acache.modifications)
+    @test isempty(modcache.A.modifications)
     Amod_update_results = OSQP.solve!(model)
     @test !isapprox(baseresults.x, Amod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
     @test !isapprox(qmod_update_results.x, Amod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
     Amod = copy(A)
     Amod[row, col] = val
     model3 = OSQP.Model()
-    OSQP.setup!(model3; P = P, q = modcache.qcache.data, A = Amod, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    OSQP.setup!(model3; P = P, q = modcache.q.data, A = Amod, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
     Amod_setup_results = OSQP.solve!(model3)
     @test Amod_update_results.x ≈ Amod_setup_results.x atol = 1e-8
 
     # MatrixModificationCache: colon indexing
-    modcache.Pcache[:] = 0.
+    modcache.P[:] = 0.
     for i = 1 : n
-        modcache.Pcache[i, i] = 1.
+        modcache.P[i, i] = 1.
     end
     MathOptInterfaceOSQP.processupdates!(model, modcache)
     Pmod_update_results = OSQP.solve!(model)
     model4 = OSQP.Model()
     Pmod = speye(n, n)
-    OSQP.setup!(model4; P = Pmod, q = modcache.qcache.data, A = Amod, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    OSQP.setup!(model4; P = Pmod, q = modcache.q.data, A = Amod, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
     Pmod_setup_results = OSQP.solve!(model4)
     @test Pmod_update_results.x ≈ Pmod_setup_results.x atol = 1e-8
 
@@ -78,21 +78,9 @@ const MOIU = MathOptInterface.Utilities
     nzinds = map(CartesianIndex, zip(I, J))
     zinds = zinds = setdiff(vec(CartesianIndices(A)), nzinds)
     for I in zinds
-        @test_throws ArgumentError modcache.Acache[I[1], I[2]] = randn(rng)
+        @test_throws ArgumentError modcache.A[I[1], I[2]] = randn(rng)
     end
-    @test_throws ArgumentError modcache.Acache[:] = 1
-end
-
-# TODO: consider moving to MOIT. However, current defaultcopy! is fine with BadObjectiveModel.
-struct BadObjectiveModel <: MOIT.BadModel end # objective sense is not FeasibilitySense, but can't get objective function
-MOI.canget(src::BadObjectiveModel, ::MOI.ObjectiveSense) = true
-MOI.get(src::BadObjectiveModel, ::MOI.ObjectiveSense) = MOI.MinSense
-MOI.canget(src::BadObjectiveModel, ::MOI.ObjectiveFunction{<:Any}) = false
-
-@testset "failcopy" begin
-    optimizer = OSQPOptimizer()
-    MOIT.failcopytestc(optimizer)
-    MOIT.failcopytest(optimizer, BadObjectiveModel(), MOI.CopyOtherError)
+    @test_throws ArgumentError modcache.A[:] = 1
 end
 
 # FIXME: type piracy. Generalize and move to MOIU.
@@ -114,13 +102,20 @@ end
 
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
-@testset "CachingOptimizer: linear problems" begin
-    excludes = String[]
-    push!(excludes, "linear7") # vector constraints
+function defaultoptimizer()
     optimizer = OSQPOptimizer()
     MOI.set!(optimizer, OSQPSettings.Verbose(), false)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
+    MOI.set!(optimizer, OSQPSettings.MaxIter(), 10000)
+    MOI.set!(optimizer, OSQPSettings.CheckTermination(), true)
+    optimizer
+end
+
+@testset "CachingOptimizer: linear problems" begin
+    excludes = String[]
+    push!(excludes, "linear7") # vector constraints
+    optimizer = defaultoptimizer()
     MOIT.contlineartest(MOIU.CachingOptimizer(OSQPModel{Float64}(), optimizer), config, excludes)
 end
 
@@ -130,9 +125,162 @@ end
     push!(excludes, "quadratic5") # QCP
     push!(excludes, "quadratic6") # QCP
     push!(excludes, "quadratic7") # SOCP
-    optimizer = OSQPOptimizer()
-    MOI.set!(optimizer, OSQPSettings.Verbose(), false)
-    MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
-    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
+    optimizer = defaultoptimizer()
     MOIT.contquadratictest(MOIU.CachingOptimizer(OSQPModel{Float64}(), optimizer), config, excludes)
+end
+
+function test_optimizer_modification(modfun::Base.Callable, model::MOI.ModelLike, optimizer::T, idxmap::MOIU.IndexMap,
+        cleanoptimizer::T, config::MOIT.TestConfig) where T<:MOI.AbstractOptimizer
+    # apply modfun to both the model and the optimizer
+    modfun(model)
+    modfun(optimizer)
+
+    # copy model into clean optimizer
+    copyresult = MOI.copy!(cleanoptimizer, model)
+    @test copyresult.status == MOI.CopySuccess
+    @test copyresult.indexmap.varmap == idxmap.varmap
+    @test copyresult.indexmap.conmap == idxmap.conmap
+
+    # call optimize! on both optimizers
+    MOI.optimize!(optimizer)
+    MOI.optimize!(cleanoptimizer)
+
+    # compare results
+    atol = config.atol
+    rtol = config.rtol
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.get(cleanoptimizer, MOI.TerminationStatus())
+    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.get(cleanoptimizer, MOI.PrimalStatus())
+    @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ MOI.get(cleanoptimizer, MOI.ObjectiveValue()) atol=atol rtol=rtol
+
+    modelvars = MOI.get(model, MOI.ListOfVariableIndices())
+    for v_model in modelvars
+        v_optimizer = idxmap[v_model]
+        @test MOI.get(optimizer, MOI.VariablePrimal(), v_optimizer) ≈ MOI.get(cleanoptimizer, MOI.VariablePrimal(), v_optimizer) atol=atol rtol=rtol
+    end
+
+    if config.duals
+        @test MOI.get(optimizer, MOI.DualStatus()) == MOI.get(cleanoptimizer, MOI.DualStatus())
+        for (F, S) in MOI.get(model, MOI.ListOfConstraints())
+            cis_model = MOI.get(model, MOI.ListOfConstraintIndices{F, S}())
+            for ci_model in cis_model
+                ci_optimizer = idxmap[ci_model]
+                @test MOI.get(optimizer, MOI.ConstraintDual(), ci_optimizer) ≈ MOI.get(cleanoptimizer, MOI.ConstraintDual(), ci_optimizer) atol=atol rtol=rtol
+            end
+        end
+    end
+end
+
+function zero_warm_start!(optimizer::MOI.ModelLike, vars, cons)
+    for vi in vars
+        MOI.set!(optimizer, MOI.VariablePrimalStart(), vi, 0.0)
+    end
+    for ci in cons
+        MOI.set!(optimizer, MOI.ConstraintDualStart(), ci, 0.0)
+    end
+end
+
+@testset "No CachingOptimizer: problem modification after copy!" begin
+    # Initial setup: modified version of MOIT.linear1test
+    # min -x
+    # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
+    #       x, y >= 0   (x, y ∈ Nonnegatives)
+    model = OSQPModel{Float64}()
+    MOI.empty!(model)
+    v = MOI.addvariables!(model, 2)
+    x, y = v
+    cf = MOI.ScalarAffineFunction([v; v; v], [0.0,0.0,1.0,1.0,0.0,0.0], 0.0)
+    c = MOI.addconstraint!(model, cf, MOI.Interval(-Inf, 1.0))
+    vc1 = MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.Interval(0.0, Inf))
+    vc2 = MOI.addconstraint!(model, v[2], MOI.Interval(0.0, Inf))
+    objf = MOI.ScalarAffineFunction([v; v; v], [0.0,0.0,-1.0,0.0,0.0,0.0], 0.0)
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    optimizer = defaultoptimizer()
+    copyresult = MOI.copy!(optimizer, model)
+    idxmap = copyresult.indexmap
+
+    # Since OSQP automatically warm starts, we need to manually zero to get repeatable results
+    zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
+    MOI.optimize!(optimizer)
+
+    # ensure that unmodified model is correct
+    atol = config.atol
+    rtol = config.rtol
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
+    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.VariablePrimal(), getindex.(idxmap, v)) ≈ [1, 0] atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FeasiblePoint
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[c]) ≈ -1 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc1]) ≈ 0 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc2]) ≈ 1 atol=atol rtol=rtol
+
+    # ensure that solving a second time results in the same answer (after zeroing warm start)
+    zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
+    # TODO: I would have expected this to pass:
+    # test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), MOIT.TestConfig(atol=0.0, rtol=0.0))
+    test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), config)
+
+    mapfrommodel(::MOI.AbstractOptimizer, x::Union{MOI.VariableIndex, <:MOI.ConstraintIndex}) = idxmap[x]
+    mapfrommodel(::MOI.ModelLike, x::Union{MOI.VariableIndex, <:MOI.ConstraintIndex}) = x
+
+    # change objective to min -2y
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        newobjf = MOI.ScalarAffineFunction([mapfrommodel(m, y)], [-2.0], 0.0)
+        F = typeof(newobjf)
+        @test MOI.canset(m, MOI.ObjectiveFunction{F}())
+        MOI.set!(m, MOI.ObjectiveFunction{F}(), newobjf)
+    end
+
+    # change x + y <= 1 to x + 2 y <= 1
+    zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarAffineFunction{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarAffineFunction(mapfrommodel.(m, [x, x, y]), [1.0, 1.0, 1.0], 0.0))
+    end
+
+    # flip the feasible set around from what it was originally and minimize +x
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        # objective
+        newobjf = MOI.SingleVariable(mapfrommodel(m, x))
+        F = typeof(newobjf)
+        @test MOI.canset(m, MOI.ObjectiveFunction{F}())
+        MOI.set!(m, MOI.ObjectiveFunction{F}(), newobjf)
+
+        # c
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarAffineFunction{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarAffineFunction(mapfrommodel.(m, [x, y]), [1.0, 1.0], 0.0))
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.Interval{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.Interval(-1.0, Inf))
+
+        # vc1
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, vc1), MOI.Interval{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, vc1), MOI.Interval(-Inf, 0.))
+
+        # vc2
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, vc2), MOI.Interval{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, vc2), MOI.Interval(-Inf, 0.))
+    end
+
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
+    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.VariablePrimal(), getindex.(idxmap, v)) ≈ [-1, 0] atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FeasiblePoint
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[c]) ≈ 1 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc1]) ≈ 0 atol=atol rtol=rtol
+    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc2]) ≈ -1 atol=atol rtol=rtol
+end
+
+# TODO: consider moving to MOIT. However, current defaultcopy! is fine with BadObjectiveModel.
+struct BadObjectiveModel <: MOIT.BadModel end # objective sense is not FeasibilitySense, but can't get objective function
+MOI.canget(src::BadObjectiveModel, ::MOI.ObjectiveSense) = true
+MOI.get(src::BadObjectiveModel, ::MOI.ObjectiveSense) = MOI.MinSense
+MOI.canget(src::BadObjectiveModel, ::MOI.ObjectiveFunction{<:Any}) = false
+
+@testset "failcopy" begin
+    optimizer = OSQPOptimizer()
+    MOIT.failcopytestc(optimizer)
+    MOIT.failcopytest(optimizer, BadObjectiveModel(), MOI.CopyOtherError)
 end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -216,7 +216,13 @@ end
     @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc1]) ≈ 0 atol=atol rtol=rtol
     @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc2]) ≈ 1 atol=atol rtol=rtol
 
-    # ensure that solving a second time results in the same answer (after zeroing warm start)
+    # test default warm start
+    tcold = MOI.get(optimizer, MOI.SolveTime())
+    MOI.optimize!(optimizer)
+    twarm = MOI.get(optimizer, MOI.SolveTime())
+    @test twarm < 0.5 * tcold # conservative; should be about an order of magnitude in this case
+
+    # ensure that solving a second time results in the same answer after zeroing warm start
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
     # TODO: I would have expected this to pass:
     # test_optimizer_modification(m -> (), model, optimizer, idxmap, defaultoptimizer(), MOIT.TestConfig(atol=0.0, rtol=0.0))

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -21,14 +21,36 @@ MOIU.@model(OSQPCachingOptimizer, # modelname
     () # typedvectorfunctions
 )
 
+# FIXME: type piracy. Generalize and move to MOIU.
+MOI.canget(optimizer::MOIU.CachingOptimizer, ::MOI.ConstraintPrimal, ::Type{<:MOI.ConstraintIndex}) = true
+function MOI.get(optimizer::MOIU.CachingOptimizer, ::MOI.ConstraintPrimal, ci::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Any})
+    f = MOI.get(optimizer, MOI.ConstraintFunction(), ci)
+    MOI.get(optimizer, MOI.VariablePrimal(), f.variable)
+end
+function MOI.get(optimizer::MOIU.CachingOptimizer, ::MOI.ConstraintPrimal, ci::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Any})
+    f = MOI.get(optimizer, MOI.ConstraintFunction(), ci)
+    ret = f.constant
+    n = length(f.variables)
+    length(f.coefficients) == n || error()
+    for i = 1 : n
+        ret += f.coefficients[i] * MOI.get(optimizer, MOI.VariablePrimal(), f.variables[i])
+    end
+    ret
+end
+
+
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Continuous linear problems" begin
     excludes = collect(keys(MOIT.contlineartests))
     deleteat!(excludes, findfirst(excludes, "linear1"))
+
+    # excludes = String[]
+    # push!(excludes, "linear8a") # OSQP returns :Primal_infeasible and doesn't provide duals
+    # push!(excludes, "linear8c") # OSQP returns :Dual_infeasible and doesn't provide primals
     optimizer = OSQPOptimizer()
     MOI.set!(optimizer, OSQPSettings.Verbose(), false)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
-    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-8)
+    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
 end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -10,6 +10,68 @@ const MOIT = MathOptInterfaceTests
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities
 
+@testset "ProblemModificationCache" begin
+    rng = MersenneTwister(1234)
+    n = 15
+    m = 10
+    q = randn(rng, n)
+    P = (X = sprandn(rng, n, n, 0.1); X' * X)
+    l = -rand(rng, m)
+    u = rand(rng, m)
+    A = sprandn(rng, m, n, 0.6)
+    modcache = MathOptInterfaceOSQP.ProblemModificationCache(P, q, A, l, u)
+
+    model = OSQP.Model()
+    OSQP.setup!(model; P = P, q = q, A = A, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    baseresults = OSQP.solve!(model)
+    @test baseresults.info.status == :Solved
+
+    # VectorModificationCache basics
+    @test !modcache.qcache.dirty
+    modcache.qcache[3] = 5.
+    @test modcache.qcache.dirty
+    @test modcache.qcache.data[3] == 5.
+
+    # Process q modifications, ensure that updating results in the same solution as calling setup! with the modified q
+    MathOptInterfaceOSQP.processupdates!(model, modcache)
+    @test !modcache.qcache.dirty
+    qmod_update_results = OSQP.solve!(model)
+    @test !isapprox(baseresults.x, qmod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
+    model2 = OSQP.Model()
+    OSQP.setup!(model2; P = P, q = modcache.qcache.data, A = A, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    qmod_setup_results = OSQP.solve!(model2)
+    @test qmod_update_results.x ≈ qmod_setup_results.x atol = 1e-8
+
+    # MatrixModificationCache basics
+    (I, J) = findn(A)
+    Amodindex = rand(rng, 1 : nnz(A))
+    row = I[Amodindex]
+    col = J[Amodindex]
+    val = randn(rng)
+    modcache.Acache[row, col] = val
+    @test any(x -> x == val, modcache.Acache.modifications)
+
+    # Process A modifications, ensure that updating results in the same solution as calling setup! with the modified A and q
+    MathOptInterfaceOSQP.processupdates!(model, modcache)
+    @test all(iszero, modcache.Acache.modifications)
+    Amod_update_results = OSQP.solve!(model)
+    @test !isapprox(baseresults.x, Amod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
+    @test !isapprox(qmod_update_results.x, Amod_update_results.x; atol = 1e-1) # ensure that new results are significantly different
+    Amod = copy(A)
+    Amod[row, col] = val
+    model3 = OSQP.Model()
+    OSQP.setup!(model3; P = P, q = modcache.qcache.data, A = Amod, l = l, u = u, verbose = false, eps_abs = 1e-8, eps_rel = 1e-16)
+    Amod_setup_results = OSQP.solve!(model3)
+    @test Amod_update_results.x ≈ Amod_setup_results.x atol = 1e-8
+
+    # Modifying the sparsity pattern is not allowed
+    nzinds = map(CartesianIndex, zip(I, J))
+    zinds = zinds = setdiff(vec(CartesianIndices(A)), nzinds)
+    for I in zinds
+        @test_throws ArgumentError modcache.Acache[I[1], I[2]] = randn(rng)
+    end
+end
+
 MOIU.@model(OSQPCacheModel, # modelname
     (), # scalarsets
     (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -1,6 +1,9 @@
 using OSQP.MathOptInterfaceOSQP
 using Base.Test
 
+using MathOptInterface
+const MOI = MathOptInterface
+
 using MathOptInterfaceTests
 const MOIT = MathOptInterfaceTests
 
@@ -21,5 +24,11 @@ MOIU.@model(OSQPCachingOptimizer, # instancename
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Continuous linear problems" begin
-    MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), OSQPOptimizer()), config)
+    excludes = collect(keys(MOIT.contlineartests))
+    deleteat!(excludes, findfirst(excludes, "linear1"))
+    optimizer = OSQPOptimizer()
+    MOI.set!(optimizer, OSQPSettings.Verbose(), false)
+    MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
+    MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-8)
+    MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
 end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -10,7 +10,7 @@ const MOIT = MathOptInterfaceTests
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities
 
-MOIU.@model(OSQPCachingOptimizer, # instancename
+MOIU.@model(OSQPCachingOptimizer, # modelname
     (), # scalarsets
     (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets
     (), # vectorsets

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -7,9 +7,9 @@ const MOIT = MathOptInterfaceTests
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities
 
-MOIU.@instance(OSQPInstanceData, # instancename
+MOIU.@model(OSQPCachingOptimizer, # instancename
     (), # scalarsets
-    (Interval,), # typedscalarsets
+    (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets
     (), # vectorsets
     (), # typedvectorsets
     (SingleVariable,), # scalarfunctions
@@ -21,8 +21,5 @@ MOIU.@instance(OSQPInstanceData, # instancename
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Continuous linear problems" begin
-    excludes = collect(keys(MOIT.contlineartests))
-    deleteat!(excludes, findfirst(excludes, "linear10"))
-
-    MOIT.contlineartest(MOIU.InstanceManager(OSQPInstanceData{Float64}(), OSQPInstance()), config, excludes)
+    MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), OSQPOptimizer()), config)
 end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -241,12 +241,20 @@ end
 
     # add a constant to the objective
     objval_before = MOI.get(optimizer, MOI.ObjectiveValue())
+    objconstant = 1.5
     test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
         @test MOI.canmodifyobjective(m, MOI.ScalarConstantChange)
-        MOI.modifyobjective!(m, MOI.ScalarConstantChange(1.5))
+        MOI.modifyobjective!(m, MOI.ScalarConstantChange(objconstant))
     end
     objval_after = MOI.get(optimizer, MOI.ObjectiveValue())
-    @test objval_after ≈ objval_before + 1.5 atol = 1e-8
+    @test objval_after ≈ objval_before + objconstant atol = 1e-8
+
+    # change objective to min -y using ScalarCoefficientChange
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        @test MOI.canmodifyobjective(m, MOI.ScalarCoefficientChange{Float64})
+        MOI.modifyobjective!(m, MOI.ScalarCoefficientChange(mapfrommodel(m, y), -1.0))
+    end
+    @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ 0.5 * objval_before + objconstant atol = 1e-8
 
     # change x + y <= 1 to x + 2 y <= 1
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -261,10 +261,15 @@ end
     @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ 0.5 * objval_before + objconstant atol = 1e-8
 
     # change x + y <= 1 to x + 2 y <= 1
-    zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
     test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
         @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarAffineFunction{Float64})
         MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarAffineFunction(mapfrommodel.(m, [x, x, y]), [1.0, 1.0, 1.0], 0.0))
+    end
+
+    # change back to x + y <= 1 using ScalarCoefficientChange
+    test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
+        @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarCoefficientChange{Float64})
+        MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarCoefficientChange(mapfrommodel(m, y), 1.0))
     end
 
     # flip the feasible set around from what it was originally and minimize +x

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -241,7 +241,6 @@ end
 
     # change x + y <= 1 to x + 2 y <= 1
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
-    println("here")
     test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
         @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarAffineFunction{Float64})
         MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarAffineFunction(mapfrommodel.(m, [x, x, y]), [1.0, 1.0, 1.0], 0.0))

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -1,0 +1,28 @@
+using OSQP.MathOptInterfaceOSQP
+using Base.Test
+
+using MathOptInterfaceTests
+const MOIT = MathOptInterfaceTests
+
+using MathOptInterfaceUtilities
+const MOIU = MathOptInterfaceUtilities
+
+MOIU.@instance(OSQPInstanceData, # instancename
+    (), # scalarsets
+    (Interval,), # typedscalarsets
+    (), # vectorsets
+    (), # typedvectorsets
+    (SingleVariable,), # scalarfunctions
+    (ScalarAffineFunction, ScalarQuadraticFunction), # typedscalarfunctions
+    (), # vectorfunctions
+    () # typedvectorfunctions
+)
+
+const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
+
+@testset "Continuous linear problems" begin
+    excludes = collect(keys(MOIT.contlineartests))
+    deleteat!(excludes, findfirst(excludes, "linear10"))
+
+    MOIT.contlineartest(MOIU.InstanceManager(OSQPInstanceData{Float64}(), OSQPInstance()), config, excludes)
+end

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -95,17 +95,6 @@ MOI.canget(src::BadObjectiveModel, ::MOI.ObjectiveFunction{<:Any}) = false
     MOIT.failcopytest(optimizer, BadObjectiveModel(), MOI.CopyOtherError)
 end
 
-MOIU.@model(OSQPModel, # modelname
-    (), # scalarsets
-    (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets
-    (), # vectorsets
-    (), # typedvectorsets
-    (SingleVariable,), # scalarfunctions
-    (ScalarAffineFunction, ScalarQuadraticFunction), # typedscalarfunctions
-    (), # vectorfunctions
-    () # typedvectorfunctions
-)
-
 # FIXME: type piracy. Generalize and move to MOIU.
 MOI.canget(optimizer::MOIU.CachingOptimizer, ::MOI.ConstraintPrimal, ::Type{<:MOI.ConstraintIndex}) = true
 function MOI.get(optimizer::MOIU.CachingOptimizer, ::MOI.ConstraintPrimal, ci::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Any})

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -286,14 +286,25 @@ end
         MOI.modifyconstraint!(m, mapfrommodel(m, vc2), MOI.Interval(-Inf, 0.))
     end
 
-    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
-    @test MOI.get(optimizer, MOI.VariablePrimal(), getindex.(idxmap, v)) ≈ [-1, 0] atol=atol rtol=rtol
-    @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FeasiblePoint
-    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[c]) ≈ 1 atol=atol rtol=rtol
-    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc1]) ≈ 0 atol=atol rtol=rtol
-    @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc2]) ≈ -1 atol=atol rtol=rtol
+    testflipped = function ()
+        @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(optimizer, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        @test MOI.get(optimizer, MOI.VariablePrimal(), getindex.(idxmap, v)) ≈ [-1, 0] atol=atol rtol=rtol
+        @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[c]) ≈ 1 atol=atol rtol=rtol
+        @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc1]) ≈ 0 atol=atol rtol=rtol
+        @test MOI.get(optimizer, MOI.ConstraintDual(), idxmap[vc2]) ≈ -1 atol=atol rtol=rtol
+    end
+    testflipped()
+
+    # update settings
+    @test optimizer.results.info.status_polish == 0
+    @test MOI.canset(optimizer, OSQPSettings.Polish())
+    MOI.set!(optimizer, OSQPSettings.Polish(), true)
+    MOI.optimize!(optimizer)
+    @test optimizer.results.info.status_polish == 1
+    testflipped()
 end
 
 @testset "RawSolver" begin

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -42,12 +42,12 @@ end
 const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Continuous linear problems" begin
-    excludes = collect(keys(MOIT.contlineartests))
-    deleteat!(excludes, findfirst(excludes, "linear1"))
+    # excludes = collect(keys(MOIT.contlineartests))
+    # deleteat!(excludes, findfirst(excludes, "linear1"))
+    # deleteat!(excludes, findfirst(excludes, "linear8a"))
 
-    # excludes = String[]
-    # push!(excludes, "linear8a") # OSQP returns :Primal_infeasible and doesn't provide duals
-    # push!(excludes, "linear8c") # OSQP returns :Dual_infeasible and doesn't provide primals
+    excludes = String[]
+    push!(excludes, "linear7") # vector constraints
     optimizer = OSQPOptimizer()
     MOI.set!(optimizer, OSQPSettings.Verbose(), false)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -108,7 +108,7 @@ function defaultoptimizer()
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOI.set!(optimizer, OSQPSettings.MaxIter(), 10000)
-    MOI.set!(optimizer, OSQPSettings.CheckTermination(), true)
+    # MOI.set!(optimizer, OSQPSettings.CheckTermination(), true) # This seems to cause random test failures!
     optimizer
 end
 
@@ -175,7 +175,7 @@ function zero_warm_start!(optimizer::MOI.ModelLike, vars, cons)
         MOI.set!(optimizer, MOI.VariablePrimalStart(), vi, 0.0)
     end
     for ci in cons
-        MOI.set!(optimizer, MOI.ConstraintDualStart(), ci, 0.0)
+        MOI.set!(optimizer, MOI.ConstraintDualStart(), ci, -0.0)
     end
 end
 
@@ -241,6 +241,7 @@ end
 
     # change x + y <= 1 to x + 2 y <= 1
     zero_warm_start!(optimizer, values(idxmap.varmap), values(idxmap.conmap))
+    println("here")
     test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), config) do m
         @test MOI.canmodifyconstraint(m, mapfrommodel(m, c), MOI.ScalarAffineFunction{Float64})
         MOI.modifyconstraint!(m, mapfrommodel(m, c), MOI.ScalarAffineFunction(mapfrommodel.(m, [x, x, y]), [1.0, 1.0, 1.0], 0.0))

--- a/test/MathOptInterfaceOSQP.jl
+++ b/test/MathOptInterfaceOSQP.jl
@@ -10,7 +10,7 @@ const MOIT = MathOptInterfaceTests
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities
 
-MOIU.@model(OSQPCachingOptimizer, # modelname
+MOIU.@model(OSQPCacheModel, # modelname
     (), # scalarsets
     (Interval, LessThan, GreaterThan, EqualTo), # typedscalarsets
     (), # vectorsets
@@ -48,7 +48,7 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
     MOI.set!(optimizer, OSQPSettings.Verbose(), false)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
-    MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
+    MOIT.contlineartest(MOIU.CachingOptimizer(OSQPCacheModel{Float64}(), optimizer), config, excludes)
 end
 
 @testset "Continuous quadratic problems" begin
@@ -61,5 +61,5 @@ end
     MOI.set!(optimizer, OSQPSettings.Verbose(), false)
     MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-16)
-    MOIT.contquadratictest(MOIU.CachingOptimizer(OSQPCachingOptimizer{Float64}(), optimizer), config, excludes)
+    MOIT.contquadratictest(MOIU.CachingOptimizer(OSQPCacheModel{Float64}(), optimizer), config, excludes)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ tests = [
     "unconstrained.jl",
     "warm_start.jl",
     "update_matrices.jl",
-    "mpbinterface.jl"
+    "mpbinterface.jl",
+    "MathOptInterfaceOSQP.jl"
     ]
 
 println("Running tests:")


### PR DESCRIPTION
(Based off of #9)

I think I at least have the basics down now. For example, the following works:
```julia
using OSQP, JuMP

solver = OSQP.MathOptInterfaceOSQP.OSQPInstance()
m = Model(solver = solver)
@variable(m, x)
@variable(m, y)
@constraint(m, 1 <= x <= 4)
@constraint(m, 2 <= y <= Inf)
@objective(m, Min, x^2 + y^2)
status = solve(m)
@show JuMP.resultvalue(x)
@show JuMP.resultvalue(y)
@show JuMP.objectivevalue(m)
```
For this you need:
* JuMP, latest master
* [MathOptInterface](https://github.com/JuliaOpt/MathOptInterface.jl), latest master
* [MathOptInterfaceUtilities](https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl), latest master

Status:
* Tests:
  * [x] MathOptInterfaceTests
  * [x] Feasibility problem - https://github.com/JuliaOpt/MathOptInterface.jl/pull/241
  * [x] Illegal objective function
  * [x] SingleVariable objective function in copy! -https://github.com/JuliaOpt/MathOptInterface.jl/pull/244
  * [x] SingleVariable objective function after modification
  * [ ] warm start from `copy!` (kind of awaiting resolution of https://github.com/JuliaOpt/MathOptInterfaceBridges.jl/issues/88)
  * [x] warm start as problem modification
  * [x] updating settings after copy!
  * [x] free!
  * [x] RawSolver
  * [x] SolveTime
  * [x] isvalid for VariableIndex?
  * [x] ScalarCoefficientChange for constraints
  * [x] ScalarConstantChange for objective function
* ~~[ ]  Support for vector constraints.~~ I'm not going to bother with that in this PR. We were also discussing having CachingOptimizer provide fallback support for this.
* Some decisions are awaiting further discussion, e.g.:
  * [x]  https://github.com/JuliaOpt/MathOptInterface.jl/pull/210 (`get`/`canget` safety)
  * [x]  https://github.com/JuliaOpt/MathOptInterface.jl/issues/213 (which constraint types to implement)
* I think a few things could be extracted out to MOIU or MOI
  * [ ] `processobjective!`
  * [ ] `processconstraints!`
  * [ ] `constant` function
* [x] Problem modification. This is partly hard to implement because we can't fit the kinds of modification that OSQP.jl currently exposes into the MOI framework. We should discuss this further.
* [ ] Get rid of `ConstraintPrimal` hack after making `ConstraintPrimal` tests in MOIT optional.
* [x] `set!` methods for warm start