### PR TITLE
MOI constructor option to initialize non-updateable settings

### DIFF
--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -63,12 +63,12 @@ mutable struct OSQPOptimizer <: MOI.AbstractOptimizer
     warmstartcache::WarmStartCache{Float64}
     rowranges::Dict{Int, UnitRange{Int}}
 
-    function OSQPOptimizer()
+    function OSQPOptimizer(; settings...)
         inner = OSQP.Model()
         hasresults = false
         results = OSQP.Results()
         isempty = true
-        settings = Dict{Symbol, Any}()
+        settings = Dict{Symbol,Any}(settings)
         sense = MOI.MinSense
         objconstant = 0.
         constrconstant = Float64[]


### PR DESCRIPTION
I couldn't find an existing MOI way to set the value of OSQP settings that aren't in `OSQP.UPDATABLE_SETTINGS` (e.g., `linsys_solver` or any of the asterisk-less options [here](http://osqp.readthedocs.io/en/latest/interfaces/solver_settings.html)), so this is a simple change that allows for these settings to be passed in at `OSQPOptimizer` construction.

This proposed change allows for syntax like `optimizer = OSQPOptimizer(linsys_solver="mkl pardiso")`; alternatively if we feel like passing in a dictionary would be better (e.g., in case we ever want to include something other than settings in the `OSQPOptimizer` constructor arguments) I'd be happy with something like
```julia
function OSQPOptimizer(; settings=Dict{Symbol, Any}())
# OSQPOptimizer(settings=Dict(:linsys_solver=>"mkl pardiso"))
```
as well.