### PR TITLE
Update to new constraint modification API in MOI v0.4.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ BinDeps
 julia 0.6
 Compat
 MathProgBase 0.7 0.8
-MathOptInterface 0.3 0.4
+MathOptInterface 0.4 0.5


### PR DESCRIPTION
This updates the MathOptInterface compatibility for the constraint modification changes in https://github.com/JuliaOpt/MathOptInterface.jl/pull/388 which just came in with MathOptInterface v0.4.0. 

@tkoolen could you take a look? The biggest change (other than all the name changes) is that `canmodifyconstraint(::Optimizer, ci::CI, set::AbstractSet)` becomes `canset(::Optimizer, ::ConstraintSet, ::Type{CI})`. So we only have the type of the constraint index, not its value. That means that the actual `isvalid` check on the value `ci` has to happen inside `set!` instead of `canset`. 