### PR TITLE
Update for OSQP 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 0.2.0 (23 July 2018): OSQP v0.4.0
+-----------------------------------------
+* Upgraded OSQP to 0.4.0 version
+
 Version 0.1.5 (12 June 2018): OSQP v0.3.1
 -----------------------------------------
 * Upgraded OSQP to 0.3.1 version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.2.0 (23 July 2018): OSQP v0.4.0
+Version 0.2.0 (24 July 2018): OSQP v0.4.0
 -----------------------------------------
 * Upgraded OSQP to 0.4.0 version
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -44,7 +44,7 @@ downloadsdir = joinpath(BinDeps.depsdir(osqp),"downloads")
 libname = "libosqp.$(dlext)"
 
 # File move rule to move QDLDL sources
-type FileMoveRule <: BinDeps.BuildStep
+struct FileMoveRule <: BinDeps.BuildStep
     src::AbstractString
     dest::AbstractString
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,6 +10,7 @@ osqp = library_dependency("osqp", aliases=["libosqp"])
 
 # Current version
 version = "0.4.0"
+qdldl_version = "0.1.2"
 
 # Get current operating system
 osqp_platform =
@@ -26,7 +27,6 @@ end
 
 # Provide binaries for each operating system
 archive_name="osqp-$version-$osqp_platform$(Sys.WORD_SIZE)"
-
 provides(Binaries, URI("https://dl.bintray.com/bstellato/generic/OSQP/$version/$archive_name.tar.gz"), [osqp], unpacked_dir="$archive_name/lib", os=:Darwin)
 provides(Binaries, URI("https://dl.bintray.com/bstellato/generic/OSQP/$version/$archive_name.tar.gz"), [osqp], unpacked_dir="$archive_name/lib", os=:Windows)
 
@@ -38,22 +38,36 @@ provides(Sources, URI("https://github.com/oxfordcontrol/osqp/archive/v$version.t
 prefix = joinpath(BinDeps.depsdir(osqp),"usr")
 srcdir = joinpath(BinDeps.depsdir(osqp),"src","osqp-$version")
 blddir = joinpath(srcdir, "build")
+downloadsdir = joinpath(BinDeps.depsdir(osqp),"downloads")
 
 # Define library name
 libname = "libosqp.$(dlext)"
 
+# File move rule to move QDLDL sources
+type FileMoveRule <: BinDeps.BuildStep
+    src::AbstractString
+    dest::AbstractString
+end
+Base.run(fc::FileMoveRule) = isfile(fc.dest) || mv(fc.src, fc.dest, remove_destination=true)
 
 provides(SimpleBuild,
     (@build_steps begin
     GetSources(osqp)
+    # Copy QDLDL sources inside OSQP sources
+    FileDownloader("https://github.com/oxfordcontrol/qdldl/archive/v$qdldl_version.tar.gz",
+		   joinpath(downloadsdir, "external", "qdldl-$qdldl_version.tar.gz"))
+    FileUnpacker(joinpath(downloadsdir, "external", "qdldl-$qdldl_version.tar.gz"),
+		 joinpath(srcdir, downloadsdir),
+		 "qdldl-$qdldl_version")
+    FileMoveRule(joinpath(srcdir, downloadsdir, "qdldl-$qdldl_version"),
+		 joinpath(srcdir, "lin_sys", "direct", "qdldl", "qdldl_sources"))
     CreateDirectory(joinpath(prefix, "lib"))
     @build_steps begin
-        # ChangeDirectory(srcdir)
         CreateDirectory(blddir)
         @build_steps begin
         ChangeDirectory(blddir)
         FileRule(joinpath(prefix, "lib", libname), @build_steps begin
-            `cmake -G "Unix Makefiles" -DUNITTESTS=OFF ..`
+            `cmake -G "Unix Makefiles" ..`
             `make osqp`
             `mv out/$libname $prefix/lib`
         end)
@@ -61,8 +75,6 @@ provides(SimpleBuild,
     end
     end),
 [osqp], os = :Linux)
-
-
 
 
 @BinDeps.install Dict(:osqp => :osqp)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,7 +9,7 @@ using Compat.Libdl
 osqp = library_dependency("osqp", aliases=["libosqp"])
 
 # Current version
-version = "0.3.1"
+version = "0.4.0"
 
 # Get current operating system
 osqp_platform =

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -532,7 +532,7 @@ function MOI.get(optimizer::OSQPOptimizer, a::MOI.TerminationStatus)
     elseif osqpstatus == :Primal_infeasible_inaccurate
         MOI.AlmostSuccess
     elseif osqpstatus == :Non_convex
-	MOI.InvalidModel
+        MOI.InvalidModel
     end
 end
 

--- a/src/MathOptInterfaceOSQP.jl
+++ b/src/MathOptInterfaceOSQP.jl
@@ -531,6 +531,8 @@ function MOI.get(optimizer::OSQPOptimizer, a::MOI.TerminationStatus)
         MOI.AlmostSuccess
     elseif osqpstatus == :Primal_infeasible_inaccurate
         MOI.AlmostSuccess
+    elseif osqpstatus == :Non_convex
+	MOI.InvalidModel
     end
 end
 
@@ -548,7 +550,7 @@ function MOI.get(optimizer::OSQPOptimizer, a::MOI.PrimalStatus)
         MOI.NearlyInfeasibilityCertificate
     elseif osqpstatus == :Dual_infeasible
         MOI.InfeasibilityCertificate
-    else # :Interrupted, :Max_iter_reached, :Solved_inaccurate (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
+    else # :Interrupted, :Max_iter_reached, :Solved_inaccurate, :Non_convex (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
         MOI.UnknownResultStatus
     end
 end
@@ -567,7 +569,7 @@ function MOI.get(optimizer::OSQPOptimizer, a::MOI.DualStatus)
         MOI.AlmostInfeasibilityCertificate
     elseif osqpstatus == :Solved
         MOI.FeasiblePoint
-    else # :Interrupted, :Max_iter_reached, :Solved_inaccurate (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
+    else # :Interrupted, :Max_iter_reached, :Solved_inaccurate, :Non_convex (TODO: good idea? use OSQP.SOLUTION_PRESENT?)
         MOI.UnknownResultStatus
     end
 end

--- a/src/OSQP.jl
+++ b/src/OSQP.jl
@@ -25,7 +25,7 @@ function __init__()
 
 
     depsdir = realpath(joinpath(dirname(@__FILE__), "..", "deps"))
-    if (vnum.major != 0 && vnum.minor != 2)
+    if (vnum.major != 0 && vnum.minor != 4)
         error("Current OSQP version installed is $(osqp_version()), but we require version 0.4.*. Delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"OSQP\").")
     end
 end

--- a/src/OSQP.jl
+++ b/src/OSQP.jl
@@ -26,7 +26,7 @@ function __init__()
 
     depsdir = realpath(joinpath(dirname(@__FILE__), "..", "deps"))
     if (vnum.major != 0 && vnum.minor != 2)
-        error("Current OSQP version installed is $(osqp_version()), but we require version 0.2.*. Delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"OSQP\").")
+        error("Current OSQP version installed is $(osqp_version()), but we require version 0.4.*. Delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"OSQP\").")
     end
 end
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -15,6 +15,7 @@ const status_map = Dict{Int,Symbol}(4 => :Dual_infeasible_inaccurate,
     -4 => :Dual_infeasible,
     -5 => :Interrupted,
     -6 => :Time_limit_reached,
+    -7 => :Non_convex,
     -10 => :Unsolved)
 
 const SOLUTION_PRESENT = [:Solved_inaccurate, :Solved, :Max_iter_reached]

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,4 +1,4 @@
-const SUITESPARSE_LDL_SOLVER = 0
+const QDLDL_SOLVER = 0
 const MKL_PARDISO_SOLVER = 1
 
 # Define OSQP infinity constants

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -507,15 +507,15 @@ function linsys_solver_str_to_int!(settings_dict::Dict{Symbol,Any})
          # Convert to lower case
         linsys_str = lowercase(linsys_str)
 
-        if linsys_str == "suitesparse ldl"
-            settings_dict[:linsys_solver] = SUITESPARSE_LDL_SOLVER
+        if linsys_str == "qdldl"
+            settings_dict[:linsys_solver] = QDLDL_SOLVER
         elseif linsys_str == "mkl pardiso"
             settings_dict[:linsys_solver] = MKL_PARDISO_SOLVER
         elseif linsys_str == ""
-            settings_dict[:linsys_solver] = SUITESPARSE_LDL_SOLVER
+            settings_dict[:linsys_solver] = QDLDL_SOLVER
         else
-            Compat.@warn("Linear system solver not recognized. Using default SuiteSparse LDL")
-            settings_dict[:linsys_solver] = SUITESPARSE_LDL_SOLVER
+            Compat.@warn("Linear system solver not recognized. Using default QDLDL")
+            settings_dict[:linsys_solver] = QDLDL_SOLVER
 
         end
     end

--- a/src/mpbinterface.jl
+++ b/src/mpbinterface.jl
@@ -160,6 +160,7 @@ function MathProgBase.status(model::OSQPMathProgModel)::Symbol
     osqpstatus == :Dual_infeasible && (status = :Unbounded)
     osqpstatus == :Dual_infeasible_inaccurate && (status = :Unbounded)
     osqpstatus == :Time_limit_reached && (status = :UserLimit)
+    osqpstatus == :Non_convex && (status = :Error)
 
     return status
 end


### PR DESCRIPTION
Update for the new release https://github.com/oxfordcontrol/osqp/releases/tag/v0.4.0

In particular:

- Handle the new status for nonconvex problem detected `OSQP_NON_CVX`
- Adapt interface to use [qdldl](https://github.com/oxfordcontrol/qdldl/) instead of suitesparse ldl