### PR TITLE
Add unit tests

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -116,10 +116,10 @@ end
 @testset "CachingOptimizer: unit" begin
     excludes = [# Quadratic constraints are not supported
                 "solve_qcp_edge_cases",
-                # Will be fixed in https://github.com/JuliaOpt/MathOptInterface.jl/pull/537
-                "solve_blank_obj",
+                # No method get(::Optimizer, ::MathOptInterface.ConstraintPrimal, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.Nonpositives})
+                "solve_duplicate_terms_vector_affine",
                 # FIXME KeyError: key CartesianIndex(1, 2) not found
-                "Duplicate off-diagonal terms",
+                "solve_qp_edge_cases",
                 # ConstraintPrimal not supported
                 "solve_affine_deletion_edge_cases",
                 # Integer and ZeroOne sets are not supported

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -113,6 +113,23 @@ function defaultoptimizer()
     optimizer
 end
 
+@testset "CachingOptimizer: unit" begin
+    excludes = [# Quadratic constraints are not supported
+                "solve_qcp_edge_cases",
+                # Will be fixed in https://github.com/JuliaOpt/MathOptInterface.jl/pull/537
+                "solve_blank_obj",
+                # FIXME KeyError: key CartesianIndex(1, 2) not found
+                "Duplicate off-diagonal terms",
+                # ConstraintPrimal not supported
+                "solve_affine_deletion_edge_cases",
+                # Integer and ZeroOne sets are not supported
+                "solve_integer_edge_cases", "solve_objbound_edge_cases"]
+
+    optimizer = defaultoptimizer()
+    MOIT.unittest(MOIU.CachingOptimizer(OSQPModel{Float64}(), optimizer),
+                  config, excludes)
+end
+
 @testset "CachingOptimizer: linear problems" begin
     excludes = ["partial_start"]  # See comment https://github.com/JuliaOpt/MathOptInterface.jl/blob/ecf691545e67552ff437ed26ec4ddfff03c50327/src/Test/contlinear.jl#L1715
     append!(excludes,


### PR DESCRIPTION
@tkoolen The new tests are catching a bug:
```julia
Duplicate off-diagonal terms: Error During Test at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/objectives.jl:228
  Got exception outside of a @test
  KeyError: key CartesianIndex(1, 2) not found
  Stacktrace:
   [1] getindex at ./dict.jl:478 [inlined]
   [2] getindex at /home/blegat/.julia/dev/OSQP/src/modcaches.jl:80 [inlined]
   [3] set(::Optimizer, ::MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarQuadraticFunction{Float64}}, ::MathOptInterface.ScalarQuadraticFunction{Float64}) at /home/blegat/.julia/dev/OSQP/src/MOIWrapper.jl:477
   [4] set(::MathOptInterface.Utilities.CachingOptimizer{Optimizer,OSQPModel{Float64}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarQuadraticFunction{Float64}}, ::MathOptInterface.ScalarQuadraticFunction{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:367
   [5] solve_qp_edge_cases(::MathOptInterface.Utilities.CachingOptimizer{Optimizer,OSQPModel{Float64}}, ::MathOptInterface.Test.TestConfig) at /build/julia/src/julia/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1093
   [6] macro expansion at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:46 [inlined]
   [7] macro expansion at /build/julia/src/julia/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
   [8] unittest(::MathOptInterface.Utilities.CachingOptimizer{Optimizer,OSQPModel{Float64}}, ::MathOptInterface.Test.TestConfig, ::Array{String,1}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:46
   [9] macro expansion at /home/blegat/.julia/dev/OSQP/test/MOIWrapper.jl:132 [inlined]
   [10] macro expansion at /build/julia/src/julia/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
   [11] top-level scope at /home/blegat/.julia/dev/OSQP/test/MOIWrapper.jl:119
```