### PR TITLE
Allowing one bound to be unspecified

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -66,7 +66,7 @@ function setup!(model::OSQP.Model;
 
     # Check if parameters are nothing
     if ((A == nothing) & ( (l != nothing) | (u != nothing))) |
-        ((A != nothing) & ((l == nothing) | (u == nothing)))
+        ((A != nothing) & ((l == nothing) & (u == nothing)))
         error("A must be supplied together with l and u")
     end
 


### PR DESCRIPTION
It seems to me that this was the intended behaviour, since a few lines later any missing bound is filled-in with infinity.