### PR TITLE
Update for MOI v0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "≥ 0.3.0"
-MathOptInterface = "~0.8"
+MathOptInterface = "~0.9"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "≥ 0.3.0"
-MathOptInterface = "~0.9"
+MathOptInterface = "~0.9.1"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -17,10 +17,9 @@ const VI = MOI.VariableIndex
 
 const SparseTriplets = Tuple{Vector{Int}, Vector{Int}, Vector{<:Any}}
 
-const SingleVariable = MOI.SingleVariable
 const Affine = MOI.ScalarAffineFunction{Float64}
 const Quadratic = MOI.ScalarQuadraticFunction{Float64}
-const AffineConvertible = Union{Affine, SingleVariable}
+const AffineConvertible = Union{Affine, MOI.SingleVariable}
 const VectorAffine = MOI.VectorAffineFunction{Float64}
 
 const Interval = MOI.Interval{Float64}
@@ -35,14 +34,6 @@ const Nonpositives = MOI.Nonpositives
 const SupportedVectorSets = Union{Zeros, Nonnegatives, Nonpositives}
 
 import OSQP
-
-# TODO: consider moving to MOI:
-constant(f::MOI.SingleVariable) = 0
-constant(f::MOI.ScalarAffineFunction) = f.constant
-# constant(f::MOI.ScalarQuadraticFunction) = f.constant
-
-dimension(s::MOI.AbstractSet) = MOI.dimension(s)
-dimension(::MOI.AbstractScalarSet) = 1
 
 lower(::Zeros, i::Int) = 0.0
 lower(::Nonnegatives, i::Int) = 0.0
@@ -64,6 +55,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     hasresults::Bool
     results::OSQP.Results
     is_empty::Bool
+    silent::Bool
     settings::Dict{Symbol, Any} # need to store these, because they should be preserved if empty! is called
     sense::MOI.OptimizationSense
     objconstant::Float64
@@ -77,29 +69,38 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         hasresults = false
         results = OSQP.Results()
         is_empty = true
-        settings = Dict{Symbol, Any}()
-        for (name, value) in kwargs
-            settings[Symbol(name)] = value
-        end
         sense = MOI.MIN_SENSE
         objconstant = 0.
         constrconstant = Float64[]
         modcache = ProblemModificationCache{Float64}()
         warmstartcache = WarmStartCache{Float64}()
         rowranges = Dict{Int, UnitRange{Int}}()
-        new(inner, hasresults, results, is_empty, settings, sense, objconstant, constrconstant, modcache, warmstartcache, rowranges)
+        optimizer = new(inner, hasresults, results, is_empty, false,
+                        Dict{Symbol, Any}(:verbose => true), sense, objconstant,
+                        constrconstant, modcache, warmstartcache, rowranges)
+        for (key, value) in kwargs
+            MOI.set(optimizer, MOI.RawParameter(key), value)
+        end
+        return optimizer
     end
 end
 
 MOI.get(::Optimizer, ::MOI.SolverName) = "OSQP"
 
-# used to smooth out transition of OSQP v0.4 -> v0.5, TODO: remove on OSQP v0.6
-export OSQPOptimizer
-function OSQPOptimizer()
-    Base.depwarn("OSQPOptimizer() is deprecated, use OSQP.Optimizer() instead.",
-                 :OSQPOptimizer)
-    return Optimizer()
+MOI.supports(::Optimizer, ::MOI.Silent) = true
+function MOI.set(optimizer::Optimizer, ::MOI.Silent, value::Bool)
+    if optimizer.silent != value
+        optimizer.silent = value
+        if !MOI.is_empty(optimizer)
+            if optimizer.silent
+                OSQP.update_settings!(optimizer.inner; :verbose => false)
+            else
+                OSQP.update_settings!(optimizer.inner; :verbose => optimizer.settings[:verbose])
+            end
+        end
+    end
 end
+MOI.get(optimizer::Optimizer, ::MOI.Silent) = optimizer.silent
 
 hasresults(optimizer::Optimizer) = optimizer.hasresults
 
@@ -127,6 +128,9 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; copy_names=false)
     dest.sense, P, q, dest.objconstant = processobjective(src, idxmap)
     A, l, u, dest.constrconstant = processconstraints(src, idxmap, dest.rowranges)
     OSQP.setup!(dest.inner; P = P, q = q, A = A, l = l, u = u, dest.settings...)
+    if dest.silent
+        OSQP.update_settings!(dest.inner; :verbose => false)
+    end
     dest.modcache = ProblemModificationCache(P, q, A, l, u)
     dest.warmstartcache = WarmStartCache{Float64}(size(A, 2), size(A, 1))
     processprimalstart!(dest.warmstartcache.x, src, idxmap)
@@ -163,7 +167,7 @@ function assign_constraint_row_ranges!(rowranges::Dict{Int, UnitRange{Int}}, idx
         for ci_src in cis_src
             set = MOI.get(src, MOI.ConstraintSet(), ci_src)
             ci_dest = idxmap[ci_src]
-            endrow = startrow + dimension(set) - 1
+            endrow = startrow + MOI.dimension(set) - 1
             rowranges[ci_dest.value] = startrow : endrow
             startrow = endrow + 1
         end
@@ -283,7 +287,7 @@ function processconstraints!(triplets::SparseTriplets, bounds::Tuple{<:Vector, <
 end
 
 function processconstant!(c::Vector{Float64}, row::Int, f::AffineConvertible)
-    c[row] = constant(f)
+    c[row] = MOI.constant(f, Float64)
     nothing
 end
 
@@ -430,13 +434,20 @@ end # module
 
 using .OSQPSettings
 
-function MOI.set(optimizer::Optimizer, a::OSQPAttribute, value)
+_symbol(param::MOI.RawParameter) = Symbol(param.name)
+_symbol(a::OSQPAttribute) = Symbol(a)
+OSQPSettings.isupdatable(param::MOI.RawParameter) = _contains(OSQP.UPDATABLE_SETTINGS, _symbol(param))
+function MOI.set(optimizer::Optimizer, a::Union{OSQPAttribute, MOI.RawParameter}, value)
     (isupdatable(a) || MOI.is_empty(optimizer)) || throw(MOI.SetAttributeNotAllowed(a))
-    setting = Symbol(a)
+    setting = _symbol(a)
     optimizer.settings[setting] = value
     if !MOI.is_empty(optimizer)
         OSQP.update_settings!(optimizer.inner; setting => value)
     end
+end
+
+function MOI.get(optimizer::Optimizer, a::Union{OSQPAttribute, MOI.RawParameter})
+    return optimizer.settings[_symbol(a)]
 end
 
 
@@ -512,7 +523,11 @@ function MOI.get(optimizer::Optimizer, a::MOI.SolveTime)
     return optimizer.results.info.run_time
 end
 
-function MOI.get(optimizer::Optimizer, a::MOI.TerminationStatus)
+function MOI.get(optimizer::Optimizer, ::MOI.RawStatusString)
+    return string(optimizer.results.info.status)
+end
+
+function MOI.get(optimizer::Optimizer, ::MOI.TerminationStatus)
     hasresults(optimizer) || return MOI.OPTIMIZE_NOT_CALLED
     osqpstatus = optimizer.results.info.status
     if osqpstatus == :Unsolved
@@ -705,7 +720,7 @@ MOIU.@model(OSQPModel, # modelname
     (MOI.Interval, MOI.LessThan, MOI.GreaterThan, MOI.EqualTo), # typedscalarsets
     (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives), # vectorsets
     (), # typedvectorsets
-    (MOI.SingleVariable,), # scalarfunctions
+    (), # scalarfunctions
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction), # typedscalarfunctions
     (), # vectorfunctions
     (MOI.VectorAffineFunction,) # typedvectorfunctions

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -3,6 +3,7 @@ using OSQP.MathOptInterfaceOSQP
 using LinearAlgebra
 using Random
 using SparseArrays
+using Test
 
 using MathOptInterface
 const MOI = MathOptInterface
@@ -111,7 +112,9 @@ function bridged_optimizer()
 end
 
 @testset "CachingOptimizer: unit" begin
-    excludes = [# Quadratic constraints are not supported
+    excludes = [# TODO
+                "time_limit_sec",
+                # Quadratic constraints are not supported
                 "solve_qcp_edge_cases",
                 # No method get(::Optimizer, ::MathOptInterface.ConstraintPrimal, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.Nonpositives})
                 "solve_duplicate_terms_vector_affine",
@@ -120,7 +123,10 @@ end
                 # ConstraintPrimal not supported
                 "solve_affine_deletion_edge_cases",
                 # Integer and ZeroOne sets are not supported
-                "solve_integer_edge_cases", "solve_objbound_edge_cases"]
+                "solve_integer_edge_cases", "solve_objbound_edge_cases",
+                "solve_zero_one_with_bounds_1",
+                "solve_zero_one_with_bounds_2",
+                "solve_zero_one_with_bounds_3"]
 
     MOIT.unittest(bridged_optimizer(), config, excludes)
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -6,12 +6,8 @@ using SparseArrays
 
 using MathOptInterface
 const MOI = MathOptInterface
-
-using MathOptInterface.Test
-const MOIT = MathOptInterface.Test
-
-using MathOptInterface.Utilities
-const MOIU = MathOptInterface.Utilities
+const MOIT = MOI.Test
+const MOIU = MOI.Utilities
 
 const Affine = MOI.ScalarAffineFunction{Float64}
 
@@ -105,7 +101,7 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 function defaultoptimizer()
     optimizer = OSQP.Optimizer()
-    MOI.set(optimizer, OSQPSettings.Verbose(), false)
+    MOI.set(optimizer, MOI.Silent(), true)
     MOI.set(optimizer, OSQPSettings.EpsAbs(), 1e-8)
     MOI.set(optimizer, OSQPSettings.EpsRel(), 1e-16)
     MOI.set(optimizer, OSQPSettings.MaxIter(), 10000)
@@ -126,7 +122,7 @@ end
                 "solve_integer_edge_cases", "solve_objbound_edge_cases"]
 
     optimizer = defaultoptimizer()
-    MOIT.unittest(MOIU.CachingOptimizer(OSQPModel{Float64}(), optimizer),
+    MOIT.unittest(MOIU.CachingOptimizer(MOIU.UniversalFallback(OSQPModel{Float64}()), optimizer),
                   config, excludes)
 end
 


### PR DESCRIPTION
- [ ] Fix `Silent`. It seems `:verbose` is ignored when it is set by `update_settings!`, i.e. by `osqp_update_verbose`. @bstellato Any idea ?
- [ ] Implement `DualObjectiveValue`. @bstellato How do we get that from OSQP ?
- [ ] Implement `TimeLimitSec`.

Support for `SingleVariable` is removed because the index should be equal to the variable index. It was bridged inside this wrapper anyway so it is better if it is not supported and relies on `ScalarFuntionizeBridge`: http://www.juliaopt.org/MathOptInterface.jl/dev/apireference/#MathOptInterface.Bridges.ScalarFunctionizeBridge