### PR TITLE
add Random as a test dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,9 @@ MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test", "Compat"]
+test = ["Test", "Compat", "Random"]


### PR DESCRIPTION
Test still fails locally with

```
 Test: non_convex.jl
ERROR in LDL_factor: Error in KKT matrix LDL factorization when computing the nonzero elements. The problem seems to be non-convex
ERROR in osqp_setup: Linear systems solver initialization failure
Test Summary: | Pass  Total
non_convex    |    3      3
 Test: polishing.jl
polish_random: Test Failed at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:119
  Expression: isapprox(results.x, x_test, atol=tol)
   Evaluated: isapprox([-0.07834457077462488, 0.06720261781221491, 0.2843906239129448, 0.06109454772892296, -0.008062655163817385, 0.5039243785523424, -0.1950870834524256, 0.4099735503580444, -0.06964359907200932, -0.23977566987501392  …  -0.08383220309627627, 0.1767233494405075, 0.17889294459965768, -0.6012858003864514, 0.5967402127073677, -1.207251040635904, -0.19787853937254393, -0.1113873030915415, 0.43319962004388013, 0.6163373703792243], [0.369834, -0.0209277, 0.068939, -0.604151, 0.60773, -0.715965, -0.128837, -0.593642, 0.928932, 0.678794  …  -0.191354, 1.12286, -0.593261, -0.0932879, 0.0286826, -0.0257784, 0.358456, -0.0693514, -0.00358498, -0.0270959]; atol=0.001)
Stacktrace:
 [1] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:119
 [2] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [3] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:77
 [4] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [5] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:16
polish_random: Test Failed at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:120
  Expression: isapprox(results.y, y_test, atol=tol)
   Evaluated: isapprox([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.083085447651147, 0.0  …  0.0, -0.2384176091635765, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.01332335063224858], [4.88779e-14, 0.441478, 5.89704e-14, 1.76439e-13, 8.10529e-15, 4.9186e-14, 5.00637e-14, 2.00889e-14, 5.39402e-13, -1.9796e-14  …  0.206435, -0.196264, 1.06762e-14, 0.338783, 7.58781e-10, -0.105739, 3.30014e-13, -4.05467e-14, 3.3212e-14, -0.161755]; atol=0.001)
Stacktrace:
 [1] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:120
 [2] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [3] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:77
 [4] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [5] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:16
polish_random: Test Failed at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:121
  Expression: isapprox(results.info.obj_val, obj_test, atol=tol)
   Evaluated: isapprox(-3.2211271987732575, -6.021607803961248; atol=0.001)
Stacktrace:
 [1] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:121
 [2] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [3] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:77
 [4] top-level scope at /Users/kristoffer/julia/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
 [5] top-level scope at /Users/kristoffer/JuliaPkgEval/OSQP.jl/test/polishing.jl:16
```