### PR TITLE
Fix Silent

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -126,10 +126,11 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; copy_names=false)
     assign_constraint_row_ranges!(dest.rowranges, idxmap, src)
     dest.sense, P, q, dest.objconstant = processobjective(src, idxmap)
     A, l, u, dest.constrconstant = processconstraints(src, idxmap, dest.rowranges)
-    OSQP.setup!(dest.inner; P = P, q = q, A = A, l = l, u = u, dest.settings...)
+    settings = copy(dest.settings)
     if dest.silent
-        OSQP.update_settings!(dest.inner; :verbose => false)
+        settings[:verbose] = false
     end
+    OSQP.setup!(dest.inner; P = P, q = q, A = A, l = l, u = u, settings...)
     dest.modcache = ProblemModificationCache(P, q, A, l, u)
     dest.warmstartcache = WarmStartCache{Float64}(size(A, 2), size(A, 1))
     processprimalstart!(dest.warmstartcache.x, src, idxmap)


### PR DESCRIPTION
The line `OSQP.update_settings!(dest.inner; :verbose => false)` does not seem to have any effect so this PR modifies the `settings` given to `setup!`. This is the approach used in most MOI wrappers.