### PR TITLE
Remove support for SingleVariable objective

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "≥ 0.3.0"
-MathOptInterface = "~0.9.1"
+MathOptInterface = "~0.9.3"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 


### PR DESCRIPTION
This structure of objective is not exploited by OSQP, it is handled the
same way as a `ScalarQuadraticFunction`. Objective bridges can no
transform it automatically so solvers should not support it.
Support for `ScalarAffineFunction` should also be removed for the same reason but there is currently no objective bridge for transforming `ScalarAffineFunction` into `ScalarQuadraticFunction`.