### PR TITLE
Add conversion from Ccsc to SparseMatrixCSC

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -48,7 +48,6 @@ function ManagedCcsc(M::SparseMatrixCSC)
     ManagedCcsc(length(M.nzval), m, n, p, i, x, -1)
 end
 
-import Base.unsafe_convert
 # TODO this is a pun on the function
 function Base.unsafe_convert(::Type{SparseMatrixCSC}, c::OSQP.Ccsc)
   m = c.m

--- a/src/types.jl
+++ b/src/types.jl
@@ -49,7 +49,7 @@ function ManagedCcsc(M::SparseMatrixCSC)
 end
 
 # TODO this is a pun on the function
-function Base.unsafe_convert(::Type{SparseMatrixCSC}, c::OSQP.Ccsc)
+function Base.convert(::Type{SparseMatrixCSC}, c::OSQP.Ccsc)
   m = c.m
   n = c.n
   nzmax = c.nzmax

--- a/src/types.jl
+++ b/src/types.jl
@@ -48,7 +48,6 @@ function ManagedCcsc(M::SparseMatrixCSC)
     ManagedCcsc(length(M.nzval), m, n, p, i, x, -1)
 end
 
-# TODO this is a pun on the function
 function Base.convert(::Type{SparseMatrixCSC}, c::OSQP.Ccsc)
   m = c.m
   n = c.n

--- a/src/types.jl
+++ b/src/types.jl
@@ -48,6 +48,18 @@ function ManagedCcsc(M::SparseMatrixCSC)
     ManagedCcsc(length(M.nzval), m, n, p, i, x, -1)
 end
 
+import Base.unsafe_convert
+# TODO this is a pun on the function
+function Base.unsafe_convert(::Type{SparseMatrixCSC}, c::OSQP.Ccsc)
+  m = c.m
+  n = c.n
+  nzmax = c.nzmax
+  nzval = [unsafe_load(c.x, i) for i=1:nzmax]
+  rowval = [unsafe_load(c.i, i) for i=1:nzmax] .+ 1
+  colptr = [unsafe_load(c.p, i) for i=1:(n+1)] .+ 1
+  SparseMatrixCSC(m, n, colptr, rowval, nzval)
+end
+
 # Returns an Ccsc matrix. The vectors are *not* GC tracked in the struct.
 # Use this only when you know that the managed matrix will outlive the Ccsc
 # matrix.

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -2,7 +2,7 @@ using SparseArrays: SparseMatrixCSC, sparse
 using LinearAlgebra: I
 using OSQP: Ccsc, ManagedCcsc
 @testset "sparse matrix interface roundtrip" begin
-    jl = sparse(I(5))
+    jl = sparse(Matrix{Bool}(LinearAlgebra.I, 5, 5))
     mc = ManagedCcsc(jl)
     c = Ccsc(mc)
     jl2 = convert(SparseMatrixCSC, c)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,0 +1,10 @@
+using SparseArrays: SparseMatrixCSC, sparse
+using LinearAlgebra: I
+using OSQP: Ccsc, ManagedCcsc
+@testset "sparse matrix interface roundtrip" begin
+    jl = sparse(I(5))
+    mc = ManagedCcsc(jl)
+    c = Ccsc(mc)
+    jl2 = Base.unsafe_convert(SparseMatrixCSC, c)
+    @test jl == jl2
+end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -5,6 +5,6 @@ using OSQP: Ccsc, ManagedCcsc
     jl = sparse(I(5))
     mc = ManagedCcsc(jl)
     c = Ccsc(mc)
-    jl2 = Base.unsafe_convert(SparseMatrixCSC, c)
+    jl2 = convert(SparseMatrixCSC, c)
     @test jl == jl2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ tests = [
     "warm_start.jl",
     "update_matrices.jl",
     "MPB_wrapper.jl",
-    "MOI_wrapper.jl"
+    "MOI_wrapper.jl",
+    "interface.jl",
     ]
 
 println("Running tests:")


### PR DESCRIPTION
I was using this to verify that `MathOptInterface` was expressing the problem to OSQP correctly. It also gives visibility into how OSQP scales the problem data, and it could be useful for debugging other things, such as matrices in the workspace.

This is a pun on `unsafe_convert`, I am asking what the correct name would be in https://github.com/JuliaLang/julia/issues/33763