### PR TITLE
Simplify problem data to avoid numerical failures.

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -400,7 +400,7 @@ end
         newcoeffs = copy(coeffs)
         modindex = rand(rng, 1 : length(newcoeffs))
         newcoeffs[modindex] = 0
-        newconst = 5 .* (rand(rng, length(u)) .- 0.5)
+        newconst = round.(5 .* (rand(rng, length(u)) .- 0.5); digits = 2)
         test_optimizer_modification(model, optimizer, idxmap, defaultoptimizer(), randvectorconfig) do m
             attr = MOI.ConstraintFunction()
             ci = mapfrommodel(m, c)


### PR DESCRIPTION
On Julia 1.5 and MOI v0.9.15, test number 79 failed to converge. A
better, long-term fix would be to choose a few good modifications to
test, but this hack seemed to resolve the issue.

cc @blegat 