### PR TITLE
Symmetrize -> upper triangularize in copy from ModelLike

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -219,7 +219,7 @@ function processobjective(src::MOI.ModelLike, idxmap)
             I = [Int(idxmap[term.variable_index_1].value) for term in fquadratic.quadratic_terms]
             J = [Int(idxmap[term.variable_index_2].value) for term in fquadratic.quadratic_terms]
             V = [term.coefficient for term in fquadratic.quadratic_terms]
-            symmetrize!(I, J, V)
+            upper_triangularize!(I, J, V)
             P = sparse(I, J, V, n, n)
             processlinearterms!(q, fquadratic.affine_terms, idxmap)
             c = fquadratic.constant
@@ -253,14 +253,12 @@ function processlinearterms!(q, terms::Vector{<:MOI.ScalarAffineTerm}, idxmap::M
     processlinearterms!(q, terms, var -> idxmap[var])
 end
 
-function symmetrize!(I::Vector{Int}, J::Vector{Int}, V::Vector)
+function upper_triangularize!(I::Vector{Int}, J::Vector{Int}, V::Vector)
     n = length(V)
     (length(I) == length(J) == n) || error()
     for i = 1 : n
-        if I[i] != J[i]
-            push!(I, J[i])
-            push!(J, I[i])
-            push!(V, V[i])
+        if I[i] > J[i]
+            I[i], J[i] = J[i], I[i]
         end
     end
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -360,7 +360,7 @@ end
     u = [0., 0., -15, 100, 80]
     A = sparse(Float64[-1 0; 0 -1; -1 -3; 2 5; 3 4])
     I, J, coeffs = findnz(A)
-    objf = MOI.ScalarQuadraticFunction(term.(q, x), [term(2 * P11, x[1], x[1])], 0.0)
+    objf = MOI.ScalarQuadraticFunction(term.(q, x), [term(2 * P11, x[1], x[1]), term(0.0, x[1], x[2])], 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     cf = MOI.VectorAffineFunction(MOI.VectorAffineTerm.(Int64.(I), term.(coeffs, map(j -> getindex(x, j), J))), -u)


### PR DESCRIPTION
In [0.6.0](https://github.com/oxfordcontrol/osqp/releases/tag/v0.6.0), OSQP started requiring that `P` be upper triangular. This was already handled in the direct workflow using `MOI.set(optimizer::Optimizer, a::MOI.ObjectiveFunction{Quadratic}, obj::Quadratic)`, 

https://github.com/oxfordcontrol/OSQP.jl/blob/f50490536e41da2fef5f03216223090bd30698f8/src/MOI_wrapper.jl#L494

but not in the copy-from-`ModelLike` workflow, where instead we were explicitly _symmetrizing_ `P`.

Modified a test to show the failure, then fixed it.