### PR TITLE
Handle case of changing sparsity pattern

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -492,6 +492,9 @@ function MOI.set(optimizer::Optimizer, a::MOI.ObjectiveFunction{Quadratic}, obj:
         col = term.variable_index_2.value
         coeff = term.coefficient
         row > col && ((row, col) = (col, row)) # upper triangle only
+        if !(CartesianIndex(row, col) in cache.P.cartesian_indices_set)
+            throw(MOI.SetAttributeNotAllowed(a, "This nonzero entry was not in the sparsity pattern of the objective function provided at `MOI.copy_to` and OSQP does not support changing the sparsity pattern."))
+        end
         cache.P[row, col] += coeff
     end
     processlinearterms!(optimizer.modcache.q, obj.affine_terms)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -119,8 +119,6 @@ end
                 "number_threads",
                 # No method get(::Optimizer, ::MathOptInterface.ConstraintPrimal, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.Nonpositives})
                 "solve_duplicate_terms_vector_affine",
-                # FIXME KeyError: key CartesianIndex(1, 2) not found
-                "solve_qp_edge_cases",
                 # ConstraintPrimal not supported
                 "solve_affine_deletion_edge_cases",
                 # Integer and ZeroOne sets are not supported
@@ -152,7 +150,6 @@ end
 
 @testset "CachingOptimizer: quadratic problems" begin
     excludes = String[]
-    optimizer = defaultoptimizer()
     MOIT.qptest(bridged_optimizer(), config, excludes)
 end
 


### PR DESCRIPTION
If the user sets a new objective with a different sparsity pattern, the current implementation fails with
```
Duplicate off-diagonal terms: Error During Test at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/objectives.jl:292
  Got exception outside of a @test
  KeyError: key CartesianIndex(1, 2) not found
  Stacktrace:
   [1] getindex(::Dict{CartesianIndex{2},Float64}, ::CartesianIndex{2}) at ./dict.jl:467
   [2] getindex at /home/blegat/.julia/dev/OSQP/src/modcaches.jl:78 [inlined]
   [3] set(::OSQP.MathOptInterfaceOSQP.Optimizer, ::MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarQuadraticFunction{Float64}}, ::MathOptInterface.ScalarQuadraticFunction{Float64}) at /home/blegat/.julia/dev/OSQP/src/MOI_wrapper.jl:499
   [4] set(::MathOptInterface.Utilities.CachingOptimizer{OSQP.MathOptInterfaceOSQP.Optimizer,MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarQuadraticFunction{Float64}}, ::MathOptInterface.ScalarQuadraticFunction{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:631
   [5] set(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{OSQP.MathOptInterfaceOSQP.Optimizer,MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarQuadraticFunction{Float64}}, ::MathOptInterface.ScalarQuadraticFunction{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridge_optimizer.jl:884
   [6] macro expansion at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/objectives.jl:294 [inlined]
   [7] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115 [inlined]
   [8] solve_qp_edge_cases(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{OSQP.MathOptInterfaceOSQP.Optimizer,MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/objectives.jl:294
```
We cannot update the existing OSQP model as it does not support sparsity pattern so with this PR, we throw an `MOI.SetAttributeNotAllowed` error that will make the `MOI.Utilities.CachingOptimizer` empty the optimizer and copy the model from scratch at the next `optimize!` call. With this change, we now pass the `solve_qp_edge_cases` unit test.