### PR TITLE
reject NL objectives in MOI wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -149,6 +149,11 @@ end
 MOI.is_empty(optimizer::Optimizer) = optimizer.inner.isempty
 
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
+
+    #check all model/variable/constraint attributes to
+    #ensure that everything passed is handled by the solver
+    copy_to_check_attributes(dest,src)
+
     MOI.empty!(dest)
     idxmap = MOIU.IndexMap(dest, src)
     assign_constraint_row_ranges!(dest.rowranges, idxmap, src)
@@ -166,6 +171,45 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
     processdualstart!(dest.warmstartcache.y, src, idxmap, dest.rowranges)
     return idxmap
 end
+
+function copy_to_check_attributes(dest, src)
+
+    #allowable model attributes
+    for attr in MOI.get(src, MOI.ListOfModelAttributesSet())
+        if attr == MOI.Name()           ||
+           attr == MOI.ObjectiveSense() ||
+           attr isa MOI.ObjectiveFunction
+            continue
+        end
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+
+    #allowable variable attributes
+    for attr in MOI.get(src, MOI.ListOfVariableAttributesSet())
+        if attr == MOI.VariableName() || 
+           attr == MathOptInterface.VariablePrimalStart()
+            continue
+        end
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+
+    #allowable constraint types and attributes
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
+        if !MOI.supports_constraint(dest, F, S)
+            throw(MOI.UnsupportedConstraint{F, S}())
+        end
+        for attr in MOI.get(src, MOI.ListOfConstraintAttributesSet{F, S}())
+            if attr == MOI.ConstraintName() || 
+               attr == MOI.ConstraintDualStart()
+                continue
+            end
+            throw(MOI.UnsupportedAttribute(attr))
+        end
+    end
+
+    return nothing
+end
+
 
 """
 Set up index map from `src` variables and constraints to `dest` variables and constraints.

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -152,7 +152,7 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
 
     #check all model/variable/constraint attributes to
     #ensure that everything passed is handled by the solver
-    copy_to_check_attributes(dest,src)
+    copy_to_check_attributes(dest, src)
 
     MOI.empty!(dest)
     idxmap = MOIU.IndexMap(dest, src)
@@ -176,7 +176,7 @@ function copy_to_check_attributes(dest, src)
 
     #allowable model attributes
     for attr in MOI.get(src, MOI.ListOfModelAttributesSet())
-        if attr == MOI.Name()           ||
+        if attr == MOI.Name() ||
            attr == MOI.ObjectiveSense() ||
            attr isa MOI.ObjectiveFunction
             continue
@@ -186,7 +186,7 @@ function copy_to_check_attributes(dest, src)
 
     #allowable variable attributes
     for attr in MOI.get(src, MOI.ListOfVariableAttributesSet())
-        if attr == MOI.VariableName() || 
+        if attr == MOI.VariableName() ||
            attr == MathOptInterface.VariablePrimalStart()
             continue
         end
@@ -196,11 +196,10 @@ function copy_to_check_attributes(dest, src)
     #allowable constraint types and attributes
     for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
         if !MOI.supports_constraint(dest, F, S)
-            throw(MOI.UnsupportedConstraint{F, S}())
+            throw(MOI.UnsupportedConstraint{F,S}())
         end
-        for attr in MOI.get(src, MOI.ListOfConstraintAttributesSet{F, S}())
-            if attr == MOI.ConstraintName() || 
-               attr == MOI.ConstraintDualStart()
+        for attr in MOI.get(src, MOI.ListOfConstraintAttributesSet{F,S}())
+            if attr == MOI.ConstraintName() || attr == MOI.ConstraintDualStart()
                 continue
             end
             throw(MOI.UnsupportedAttribute(attr))
@@ -209,7 +208,6 @@ function copy_to_check_attributes(dest, src)
 
     return nothing
 end
-
 
 """
 Set up index map from `src` variables and constraints to `dest` variables and constraints.

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -96,6 +96,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 end
 
 MOI.get(::Optimizer, ::MOI.SolverName) = "OSQP"
+MOI.get(::Optimizer, ::MOI.SolverVersion) = OSQP.version()
 
 MOI.supports(::Optimizer, ::MOI.Silent) = true
 function MOI.set(optimizer::Optimizer, ::MOI.Silent, value::Bool)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -64,29 +64,12 @@ function test_runtests()
         exclude = Union{String, Regex}[
             "test_attribute_SolverVersion",
             # Expected test failures:
-            #   MathOptInterface.jl issue #1431
-            "test_model_LowerBoundAlreadySet",
-            "test_model_UpperBoundAlreadySet",
-            # FIXME
-            # See https://github.com/jump-dev/MathOptInterface.jl/issues/1773
-            r"^test_infeasible_MAX_SENSE$",
-            r"test_infeasible_MAX_SENSE_offset$",
-            r"^test_infeasible_MIN_SENSE$",
-            r"test_infeasible_MIN_SENSE_offset$",
-            r"^test_infeasible_affine_MAX_SENSE$",
-            r"test_infeasible_affine_MAX_SENSE_offset$",
-            r"^test_infeasible_affine_MIN_SENSE$",
-            r"test_infeasible_affine_MIN_SENSE_offset$",
             # FIXME
             # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
             r"test_unbounded_MAX_SENSE$",
             r"test_unbounded_MAX_SENSE_offset$",
             r"^test_unbounded_MIN_SENSE$",
             r"test_unbounded_MIN_SENSE_offset$",
-            # FIXME
-            "test_model_copy_to_UnsupportedAttribute",
-            # Segfault
-            "test_model_copy_to_UnsupportedConstraint",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -61,7 +61,7 @@ function test_runtests()
     MOI.Test.runtests(
         model,
         config,
-        exclude = String[
+        exclude = Union{String, Regex}[
             "test_attribute_SolverVersion",
             # Expected test failures:
             #   MathOptInterface.jl issue #1431
@@ -69,20 +69,20 @@ function test_runtests()
             "test_model_UpperBoundAlreadySet",
             # FIXME
             # See https://github.com/jump-dev/MathOptInterface.jl/issues/1773
-            "test_infeasible_MAX_SENSE",
-            "test_infeasible_MAX_SENSE_offset",
-            "test_infeasible_MIN_SENSE",
-            "test_infeasible_MIN_SENSE_offset",
-            "test_infeasible_affine_MAX_SENSE",
-            "test_infeasible_affine_MAX_SENSE_offset",
-            "test_infeasible_affine_MIN_SENSE",
-            "test_infeasible_affine_MIN_SENSE_offset",
+            r"^test_infeasible_MAX_SENSE$",
+            r"test_infeasible_MAX_SENSE_offset$",
+            r"^test_infeasible_MIN_SENSE$",
+            r"test_infeasible_MIN_SENSE_offset$",
+            r"^test_infeasible_affine_MAX_SENSE$",
+            r"test_infeasible_affine_MAX_SENSE_offset$",
+            r"^test_infeasible_affine_MIN_SENSE$",
+            r"test_infeasible_affine_MIN_SENSE_offset$",
             # FIXME
             # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
-            "test_unbounded_MAX_SENSE",
-            "test_unbounded_MAX_SENSE_offset",
-            "test_unbounded_MIN_SENSE",
-            "test_unbounded_MIN_SENSE_offset",
+            r"test_unbounded_MAX_SENSE$",
+            r"test_unbounded_MAX_SENSE_offset$",
+            r"^test_unbounded_MIN_SENSE$",
+            r"test_unbounded_MIN_SENSE_offset$",
             # FIXME
             "test_model_copy_to_UnsupportedAttribute",
             # Segfault

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -61,7 +61,7 @@ function test_runtests()
     MOI.Test.runtests(
         model,
         config,
-        exclude = Union{String, Regex}[
+        exclude = Union{String,Regex}[
             "test_attribute_SolverVersion",
             # Expected test failures:
             # FIXME


### PR DESCRIPTION
The MOI wrapper should reject objective functions that are nonlinear.   I have implemented a check that will *only* allow models with attributes that MOI interface knows how to deal with, which implicitly rejects NLPblock etc.

Fixes the issue raised in https://github.com/orgs/osqp/discussions/706 by reporting the problem unsolvable.

Additional fix to remove regex warnings in the MOI wrapper test.